### PR TITLE
fixing 0 vs 1 indexing error in findModules; remove empty description arg for enrichr

### DIFF
--- a/PyWGCNA/wgcna.py
+++ b/PyWGCNA/wgcna.py
@@ -1782,13 +1782,13 @@ class WGCNA(GeneExp):
             if len(Sizes) > 1:
                 SizeRank = np.insert(stats.rankdata(-1 * Sizes[1:len(Sizes)], method='ordinal') + 1, 0, 1)
             else:
-                SizeRank = 1
+                SizeRank = [1]
             for i in range(len(NumLabs)):
-                OrdNumLabs.Value[i] = SizeRank[NumLabs[i]]
+                OrdNumLabs.Value[i] = SizeRank[NumLabs[i]-1]
         else:
-            SizeRank = stats.rankdata(-1 * Sizes, method='ordinal')+1
+            SizeRank = stats.rankdata(-1 * Sizes, method='ordinal')
             for i in range(len(NumLabs)):
-                OrdNumLabs.Value[i] = SizeRank[NumLabs[i]]
+                OrdNumLabs.Value[i] = SizeRank[NumLabs[i]-1]
 
         print("\tDone..\n")
 

--- a/PyWGCNA/wgcna.py
+++ b/PyWGCNA/wgcna.py
@@ -2710,7 +2710,7 @@ class WGCNA(GeneExp):
                 org = np.unique(tmp.iloc[:, i]).tolist()
                 rep = list(range(len(org)))
                 datTraits.replace(to_replace=org, value=rep,
-                                       inplace=True)
+                                  inplace=True)
             elif len(np.unique(tmp.iloc[:, i])) > 2:
                 for name in np.unique(tmp.iloc[:, i]):
                     datTraits[name] = tmp.iloc[:, i]
@@ -3020,7 +3020,6 @@ class WGCNA(GeneExp):
             enr = gp.enrichr(gene_list=geneModule.fillna("").values.tolist(),
                              gene_sets=GoSets,
                              organism=self.species,
-                             description='',
                              outdir=self.outputPath + '/figures/Go_term/' + moduleName,
                              cutoff=0.5)
             dotplot(enr.res2d,

--- a/PyWGCNA/wgcna.py
+++ b/PyWGCNA/wgcna.py
@@ -1786,7 +1786,7 @@ class WGCNA(GeneExp):
             for i in range(len(NumLabs)):
                 OrdNumLabs.Value[i] = SizeRank[NumLabs[i]]
         else:
-            SizeRank = stats.rankdata(-1 * Sizes[0:len(Sizes)], method='ordinal')
+            SizeRank = stats.rankdata(-1 * Sizes, method='ordinal')+1
             for i in range(len(NumLabs)):
                 OrdNumLabs.Value[i] = SizeRank[NumLabs[i]]
 


### PR DESCRIPTION
I believe there is an off-by-1 indexing error in https://github.com/mortazavilab/PyWGCNA/blob/main/PyWGCNA/wgcna.py#L1789

In my dataset, I am seeing that NumLabs is 1-indexed and contains values 1 through max(SizeRank). I believe we need to subtract 1 to use these as indices into SizeRank? 

I also think that https://github.com/mortazavilab/PyWGCNA/blob/main/PyWGCNA/wgcna.py#L1785 needs to be a list, rather than an int, to support indexing. 

Apologies if that is not a correct interpretation of the code, I was consistently getting "index out of range" error and this modification fixed it for me. 
