### PR TITLE
fix #119

### DIFF
--- a/PyWGCNA/comparison.py
+++ b/PyWGCNA/comparison.py
@@ -114,7 +114,7 @@ class Comparison:
                             list2 = self.geneModules[network2].index[
                                 self.geneModules[network2].moduleColors == module2].tolist()
                             num = np.intersect1d(list1, list2)
-                            fraction.loc[f"{network1}:{module1}", f"{network2}:{module2}"] = len(num) / len(list2) * 100
+                            fraction.loc[f"{network1}:{module1}", f"{network2}:{module2}"] = len(num) / len(list2)
                 else:
                     modules = self.geneModules[network1].moduleColors.unique().tolist()
                     for module in modules:
@@ -123,11 +123,13 @@ class Comparison:
 
         return fraction
 
-    def calculatePvalue(self):
+    def calculatePvalue(self, alternative='greater'):
         """
-        Calculate pvalue of fraction along multiple networks
-
-        :return: dataframe containing pvalue between all modules in all netwroks
+        Calculate pvalue of modules overlap along multiple networks using fisher exact test
+        
+        :param alternative: {'two-sided', 'less', 'greater'}, alternative hypothesis, use 'greater' to detect overlapping modules, 'less' to detect mutually exclusive modules, 'two-sided' to detect both (default: greater)
+        :type alternative: str
+        :return: dataframe containing pvalue between all modules in all networks
         :rtype: pandas dataframe
         """
 
@@ -158,11 +160,11 @@ class Comparison:
                             list2 = self.geneModules[network2].index[
                                 self.geneModules[network2].moduleColors == module2].tolist()
                             number = self.fraction.loc[f"{network1}:{module1}", f"{network2}:{module2}"] * len(
-                                list2) / 100
+                                list2)
                             table = np.array(
                                 [[nGenes - len(list1) - len(list2) + number, len(list1) - number],
                                  [len(list2) - number, number]])
-                            oddsr, p = fisher_exact(table, alternative='two-sided')
+                            oddsr, p = fisher_exact(table, alternative=alternative)
                             pvalue.loc[f"{network1}:{module1}", f"{network2}:{module2}"] = p
         self.P_value = pvalue
 


### PR DESCRIPTION
- Fix issues pointed out in #119:
- Change percentages to fractions
- Set 'greater' as the default alternative for fisher's exact test in `calculatePvalue`.
- Add `alternative` parameter  in `calculatePvalue`.
- Add a brief description of the possible alternatives. 

Just one final comment. The documentation never states that Fisher's Exact test is being performed, so the user won't know what the p-values are unless they dig into the source code and won't know what the different alternative hypothesis refer to. I believe what the p-values are should be clarified in the documentation. For this reason I have not added `alternative` as an argument to `compareNetworks`, since it would be strange to give the user control over the alternative hypothesis when they  don't know what is happening. If they know what the function does and want finer control they can still achieve it by explicitly calling `calculatePvalue`.