### PR TITLE
Bug when anndata with non string values in obs used to initialize wgcna object

### DIFF
--- a/PyWGCNA/wgcna.py
+++ b/PyWGCNA/wgcna.py
@@ -3124,7 +3124,7 @@ class WGCNA(GeneExp):
 
                 if colorBar is None:
                     palette = "lightblue"
-                elif type(colorBar) == dict:
+                elif type(self.metadataColors[colorBar]) == dict:
                     palette = cat[[colorBar]].copy()
                     palette.replace(self.metadataColors[colorBar], inplace=True)
                     palette = palette[colorBar].values

--- a/PyWGCNA/wgcna.py
+++ b/PyWGCNA/wgcna.py
@@ -2851,10 +2851,18 @@ class WGCNA(GeneExp):
                                                      tmp_pvalue.values.flatten())])) \
             .reshape(moduleTraitCor.T.shape)
 
-        sns.set(font_scale=1.5)
-        res = sns.heatmap(moduleTraitCor.T, annot=labels, fmt="", cmap='RdBu_r',
-                          vmin=-1, vmax=1, ax=ax, annot_kws={'size': 20, "weight": "bold"},
-                          xticklabels=xlabels, yticklabels=ylabels)
+        #sns.set(font_scale=1.5)
+        res = sns.heatmap(
+            moduleTraitCor.T, 
+            annot=labels, 
+            fmt="", 
+            cmap='RdBu_r',
+            vmin=-1, vmax=1, 
+            ax=ax, 
+            annot_kws={"weight": "bold"},
+            xticklabels=xlabels, yticklabels=ylabels,
+            square= True
+        )
         res.set_xticklabels(res.get_xmajorticklabels(), fontsize=20, fontweight="bold", rotation=90)
         res.set_yticklabels(res.get_ymajorticklabels(), fontsize=20, fontweight="bold")
         plt.yticks(rotation=0)

--- a/PyWGCNA/wgcna.py
+++ b/PyWGCNA/wgcna.py
@@ -3146,7 +3146,7 @@ class WGCNA(GeneExp):
                     handles = []
                     x = ind
                     y = np.repeat(3000 * metadata.index(m), len(ind))
-                    color = list(cat[m].values)
+                    color = cat[m].tolist()
                     if type(self.metadataColors[m]) == dict:
                         for n in list(self.metadataColors[m].keys()):
                             color = [self.metadataColors[m][n] if str(c) == str(n) else c for c in color]

--- a/PyWGCNA/wgcna.py
+++ b/PyWGCNA/wgcna.py
@@ -2995,10 +2995,10 @@ class WGCNA(GeneExp):
                     handles = []
                     x = ind
                     y = np.repeat(3000 * metadata.index(m), len(ind))
-                    color = sampleInfo[m].values
+                    color = list(sampleInfo[m].values)
                     if type(self.metadataColors[m]) == dict:
                         for n in list(self.metadataColors[m].keys()):
-                            color = np.where(color == n, self.metadataColors[m][n], color)
+                            color = [self.metadataColors[m][n] if c == n else c for c in color]
                             patch = mpatches.Patch(color=self.metadataColors[m][n], label=n)
                             handles.append(patch)
                         axs[0, 0].scatter(x, y, c=color, s=1600, marker='s')
@@ -3154,10 +3154,10 @@ class WGCNA(GeneExp):
                     handles = []
                     x = ind
                     y = np.repeat(3000 * metadata.index(m), len(ind))
-                    color = cat[m].values
+                    color = list(cat[m].values)
                     if type(self.metadataColors[m]) == dict:
                         for n in list(self.metadataColors[m].keys()):
-                            color = np.where(color == n, self.metadataColors[m][n], color)
+                            color = [self.metadataColors[m][n] if c == n else c for c in color]
                             patch = mpatches.Patch(color=self.metadataColors[m][n], label=n)
                             handles.append(patch)
                         if m != colorBar:

--- a/PyWGCNA/wgcna.py
+++ b/PyWGCNA/wgcna.py
@@ -2998,7 +2998,7 @@ class WGCNA(GeneExp):
                     color = list(sampleInfo[m].values)
                     if type(self.metadataColors[m]) == dict:
                         for n in list(self.metadataColors[m].keys()):
-                            color = [self.metadataColors[m][n] if c == n else c for c in color]
+                            color = [self.metadataColors[m][n] if c.__str__() == n.__str__() else c for c in color]
                             patch = mpatches.Patch(color=self.metadataColors[m][n], label=n)
                             handles.append(patch)
                         axs[0, 0].scatter(x, y, c=color, s=1600, marker='s')
@@ -3157,7 +3157,7 @@ class WGCNA(GeneExp):
                     color = list(cat[m].values)
                     if type(self.metadataColors[m]) == dict:
                         for n in list(self.metadataColors[m].keys()):
-                            color = [self.metadataColors[m][n] if c == n else c for c in color]
+                            color = [self.metadataColors[m][n] if c.__str__() == n.__str__() else c for c in color]
                             patch = mpatches.Patch(color=self.metadataColors[m][n], label=n)
                             handles.append(patch)
                         if m != colorBar:

--- a/PyWGCNA/wgcna.py
+++ b/PyWGCNA/wgcna.py
@@ -2998,7 +2998,7 @@ class WGCNA(GeneExp):
                     color = list(sampleInfo[m].values)
                     if type(self.metadataColors[m]) == dict:
                         for n in list(self.metadataColors[m].keys()):
-                            color = [self.metadataColors[m][n] if c.__str__() == n.__str__() else c for c in color]
+                            color = [self.metadataColors[m][n] if str(c) == str(n) else c for c in color]
                             patch = mpatches.Patch(color=self.metadataColors[m][n], label=n)
                             handles.append(patch)
                         axs[0, 0].scatter(x, y, c=color, s=1600, marker='s')
@@ -3157,7 +3157,7 @@ class WGCNA(GeneExp):
                     color = list(cat[m].values)
                     if type(self.metadataColors[m]) == dict:
                         for n in list(self.metadataColors[m].keys()):
-                            color = [self.metadataColors[m][n] if c.__str__() == n.__str__() else c for c in color]
+                            color = [self.metadataColors[m][n] if str(c) == str(n) else c for c in color]
                             patch = mpatches.Patch(color=self.metadataColors[m][n], label=n)
                             handles.append(patch)
                         if m != colorBar:

--- a/PyWGCNA/wgcna.py
+++ b/PyWGCNA/wgcna.py
@@ -2995,9 +2995,9 @@ class WGCNA(GeneExp):
                     handles = []
                     x = ind
                     y = np.repeat(3000 * metadata.index(m), len(ind))
-                    color = list(sampleInfo[m].values)
+                    color = sampleInfo[m].tolist()
                     if type(self.metadataColors[m]) == dict:
-                        for n in list(self.metadataColors[m].keys()):
+                        for n in self.metadataColors[m].keys():
                             color = [self.metadataColors[m][n] if str(c) == str(n) else c for c in color]
                             patch = mpatches.Patch(color=self.metadataColors[m][n], label=n)
                             handles.append(patch)
@@ -3093,25 +3093,25 @@ class WGCNA(GeneExp):
             print(f"{WARNING}Module name does not exist in {ENDC}")
             return None
         else:
-            ME = pd.DataFrame(self.datME["ME" + moduleName], columns=['eigengeneExp'])
+            ME = self.datME[["ME" + moduleName]].copy(
+                    deep= True
+                ).rename(
+                    columns= {"ME" + moduleName: 'eigengeneExp'}
+                )
 
             if combine:
                 df = ME.copy(deep=True)
                 df[metadata] = sampleInfo[metadata].copy(deep= True)
                 df["all"] = df[metadata].astype(str).apply("_".join, axis= 1)
+                df = df.sort_values("all")
                 cat = df[metadata + ["all"]].drop_duplicates()
                 ybar = df[['all', 'eigengeneExp']].groupby(['all']).mean()['eigengeneExp']
                 ebar = df[['all', 'eigengeneExp']].groupby(['all']).std()['eigengeneExp']
                 ybar = ybar.loc[cat['all']]
                 ebar = ebar.loc[cat['all']]
                 label = list(ybar.index)
-                dot = df[['all', 'eigengeneExp']].copy()
-                ind = {}
-                for i in range(cat.shape[0]):
-                    ind[cat.loc[i, 'all']] = cat.index[i]
-                dot.replace(ind, inplace=True)
-                xdot = dot['all']
-                ydot = dot['eigengeneExp']
+                xdot = df['all']
+                ydot = df['eigengeneExp']
 
                 if colorBar is None:
                     palette = "lightblue"
@@ -3141,7 +3141,7 @@ class WGCNA(GeneExp):
                                                               subplot_spec=ax_legend.get_subplotspec(),
                                                               height_ratios=height_ratios)
 
-                ind = [i for i in range(cat.shape[0])]
+                ind = cat["all"]
                 for m in metadata:
                     handles = []
                     x = ind
@@ -3185,7 +3185,6 @@ class WGCNA(GeneExp):
                 axs[0, 0].grid(False)
                 axs[0, 0].axis('off')
 
-                ind = [i for i in range(cat.shape[0])]
                 axs[1, 0].bar(ind, ybar, align='center', color=palette)
                 axs[1, 0].errorbar(ind, ybar, yerr=ebar, fmt="o", color="r")
                 axs[1, 0].scatter(xdot, ydot, c='black', alpha=0.5)

--- a/PyWGCNA/wgcna.py
+++ b/PyWGCNA/wgcna.py
@@ -14,7 +14,7 @@ from scipy.stats import t
 from scipy.stats import rankdata
 from statsmodels.formula.api import ols
 from matplotlib import colors as mcolors
-from sklearn.impute import KNNImputer 
+from sklearn.impute import KNNImputer
 from sklearn.preprocessing import scale
 import matplotlib.pyplot as plt
 import pickle
@@ -38,14 +38,14 @@ except ImportError:
         sys.exit("resource or rsrc package is not installed!")
 
 # remove runtime warning (divided by zero)
-np.seterr(divide='ignore', invalid='ignore')
-warnings.simplefilter(action='ignore', category=FutureWarning)
+np.seterr(divide="ignore", invalid="ignore")
+warnings.simplefilter(action="ignore", category=FutureWarning)
 warnings.filterwarnings("ignore")
 
 plt.rcParams["axes.edgecolor"] = "black"
 plt.rcParams["axes.linewidth"] = 1
 plt.rcParams["axes.facecolor"] = "white"
-plt.rcParams['legend.title_fontsize'] = 15
+plt.rcParams["legend.title_fontsize"] = 15
 
 sns.set_style("white")
 
@@ -143,18 +143,41 @@ class WGCNA(GeneExp):
     :type moduleTraitPvalue: pandas dataframe
     """
 
-    def __init__(self, name='WGCNA',
-                 TPMcutoff=1,
-                 powers=None, RsquaredCut=0.9, MeanCut=100,
-                 networkType="signed hybrid", TOMType="signed",
-                 minModuleSize=50, naColor="grey", cut=float('inf'),
-                 MEDissThres=0.2,
-                 species=None, level='gene', anndata=None, geneExp=None,
-                 geneExpPath=None, sep=',', geneInfo=None, sampleInfo=None,
-                 save=False, outputPath=None, figureType='pdf'):
-
-        super().__init__(species=species, level=level, anndata=anndata, geneExp=geneExp,
-                         geneExpPath=geneExpPath, sep=sep, geneInfo=geneInfo, sampleInfo=sampleInfo)
+    def __init__(
+        self,
+        name="WGCNA",
+        TPMcutoff=1,
+        powers=None,
+        RsquaredCut=0.9,
+        MeanCut=100,
+        networkType="signed hybrid",
+        TOMType="signed",
+        minModuleSize=50,
+        naColor="grey",
+        cut=float("inf"),
+        MEDissThres=0.2,
+        species=None,
+        level="gene",
+        anndata=None,
+        geneExp=None,
+        geneExpPath=None,
+        sep=",",
+        geneInfo=None,
+        sampleInfo=None,
+        save=False,
+        outputPath=None,
+        figureType="pdf",
+    ):
+        super().__init__(
+            species=species,
+            level=level,
+            anndata=anndata,
+            geneExp=geneExp,
+            geneExpPath=geneExpPath,
+            sep=sep,
+            geneInfo=geneInfo,
+            sampleInfo=sampleInfo,
+        )
 
         if powers is None:
             powers = list(range(1, 11)) + list(range(11, 21, 2))
@@ -198,9 +221,11 @@ class WGCNA(GeneExp):
 
         if self.save:
             print(f"{OKGREEN}Saving data to be True, checking requirements ...{ENDC}")
-            if not os.path.exists(self.outputPath + 'figures/'):
-                print(f"{WARNING}Figure directory does not exist!\nCreating figure directory!{ENDC}")
-                os.makedirs(self.outputPath + 'figures/')
+            if not os.path.exists(self.outputPath + "figures/"):
+                print(
+                    f"{WARNING}Figure directory does not exist!\nCreating figure directory!{ENDC}"
+                )
+                os.makedirs(self.outputPath + "figures/")
 
         self.figureType = figureType
 
@@ -215,7 +240,9 @@ class WGCNA(GeneExp):
 
         # Prepare and clean data
         # Remove cols with less than 1 TPM
-        self.datExpr = self.datExpr[:, (self.datExpr.to_df() > self.TPMcutoff).any(axis=0)]
+        self.datExpr = self.datExpr[
+            :, (self.datExpr.to_df() > self.TPMcutoff).any(axis=0)
+        ]
 
         # Check that all genes and samples have sufficiently low numbers of missing values.
         goodGenes, goodSamples, allOK = WGCNA.goodSamplesGenes(self.datExpr.to_df().T)
@@ -224,14 +251,18 @@ class WGCNA(GeneExp):
             # Optionally, print the gene and sample names that were removed:
             if np.size(goodGenes) - np.count_nonzero(goodGenes) > 0:
                 print(
-                    f"{OKGREEN} {np.size(goodGenes) - np.count_nonzero(goodGenes)} gene(s) detected as an outlier!{ENDC}")
+                    f"{OKGREEN} {np.size(goodGenes) - np.count_nonzero(goodGenes)} gene(s) detected as an outlier!{ENDC}"
+                )
                 print(
-                    f"{OKGREEN}Removing genes: {', '.join(self.datExpr.var.index[[not goodGene for goodGene in goodGenes]].tolist())}{ENDC}")
+                    f"{OKGREEN}Removing genes: {', '.join(self.datExpr.var.index[[not goodGene for goodGene in goodGenes]].tolist())}{ENDC}"
+                )
             if np.size(goodSamples) - np.count_nonzero(goodSamples) > 0:
                 print(
-                    f"{OKGREEN} {np.size(goodSamples) - np.count_nonzero(goodSamples)} sample(s) detected as an outlier!{ENDC}")
+                    f"{OKGREEN} {np.size(goodSamples) - np.count_nonzero(goodSamples)} sample(s) detected as an outlier!{ENDC}"
+                )
                 print(
-                    f"{OKGREEN}Removing samples: {', '.join(self.datExpr.obs.index[[not goodSample for goodSample in goodSamples]].tolist())}{ENDC}")
+                    f"{OKGREEN}Removing samples: {', '.join(self.datExpr.obs.index[[not goodSample for goodSample in goodSamples]].tolist())}{ENDC}"
+                )
             # Remove the offending genes and samples from the data:
             self.datExpr = self.datExpr[goodSamples, goodGenes]
 
@@ -239,18 +270,28 @@ class WGCNA(GeneExp):
         sampleTree = WGCNA.hclust(pdist(self.datExpr.to_df()), method="average")
 
         if show:
-            plt.figure(figsize=(max(25, round(self.datExpr.X.shape[0] / 20)), 10), facecolor='white')
-            dendrogram(sampleTree, color_threshold=self.cut, labels=self.datExpr.to_df().index, leaf_rotation=90,
-                       leaf_font_size=8)
-            plt.axhline(y=self.cut, c='grey', lw=1, linestyle='dashed')
-            plt.title('Sample clustering to detect outliers')
-            plt.xlabel('Samples')
-            plt.ylabel('Distances')
+            plt.figure(
+                figsize=(max(25, round(self.datExpr.X.shape[0] / 20)), 10),
+                facecolor="white",
+            )
+            dendrogram(
+                sampleTree,
+                color_threshold=self.cut,
+                labels=self.datExpr.to_df().index,
+                leaf_rotation=90,
+                leaf_font_size=8,
+            )
+            plt.axhline(y=self.cut, c="grey", lw=1, linestyle="dashed")
+            plt.title("Sample clustering to detect outliers")
+            plt.xlabel("Samples")
+            plt.ylabel("Distances")
             plt.tight_layout()
             if self.save:
-                plt.savefig(f"{self.outputPath}figures/"\
-                            f"{self.name}_sample_clustering_cleaning.{self.figureType}",
-                            bbox_inches='tight')
+                plt.savefig(
+                    f"{self.outputPath}figures/"
+                    f"{self.name}_sample_clustering_cleaning.{self.figureType}",
+                    bbox_inches="tight",
+                )
 
         # Determine cluster under the line
         clust = WGCNA.cutree(sampleTree, cutHeight=self.cut)
@@ -262,7 +303,10 @@ class WGCNA(GeneExp):
 
         print("\tDone pre-processing..\n")
 
-    def findModules(self, kwargs_function={'cutreeHybrid': {'deepSplit': 2, 'pamRespectsDendro': False}}):
+    def findModules(
+        self,
+        kwargs_function={"cutreeHybrid": {"deepSplit": 2, "pamRespectsDendro": False}},
+    ):
         """
         Clustering genes through original WGCNA pipeline: 1.pick soft threshold 2.calculating adjacency matrix 3.calculating TOM similarity matrix 4.cluster genes base of dissTOM 5.merge similar cluster dynamically
 
@@ -273,51 +317,83 @@ class WGCNA(GeneExp):
 
         # Call the network topology analysis function
         kwargs = dict()
-        if 'pickSoftThreshold' in list(kwargs_function.keys()):
-            kwargs = kwargs_function['pickSoftThreshold']
-        self.power, self.sft = WGCNA.pickSoftThreshold(self.datExpr.to_df(), RsquaredCut=self.RsquaredCut,
-                                                       MeanCut=self.MeanCut, powerVector=self.powers,
-                                                       networkType=self.networkType, **kwargs)
+        if "pickSoftThreshold" in list(kwargs_function.keys()):
+            kwargs = kwargs_function["pickSoftThreshold"]
+        self.power, self.sft = WGCNA.pickSoftThreshold(
+            self.datExpr.to_df(),
+            RsquaredCut=self.RsquaredCut,
+            MeanCut=self.MeanCut,
+            powerVector=self.powers,
+            networkType=self.networkType,
+            **kwargs,
+        )
 
-        fig, ax = plt.subplots(ncols=2, figsize=(10, 5), facecolor='white')
-        ax[0].plot(self.sft['Power'], -1 * np.sign(self.sft['slope']) * self.sft['SFT.R.sq'], 'o')
+        fig, ax = plt.subplots(ncols=2, figsize=(10, 5), facecolor="white")
+        ax[0].plot(
+            self.sft["Power"],
+            -1 * np.sign(self.sft["slope"]) * self.sft["SFT.R.sq"],
+            "o",
+        )
         for i in range(len(self.powers)):
-            ax[0].text(self.sft.loc[i, 'Power'],
-                       -1 * np.sign(self.sft.loc[i, 'slope']) * self.sft.loc[i, 'SFT.R.sq'],
-                       str(self.sft.loc[i, 'Power']), ha="center", va="center", color='black', weight='bold')
-        ax[0].axhline(0.9, color='r')
+            ax[0].text(
+                self.sft.loc[i, "Power"],
+                -1 * np.sign(self.sft.loc[i, "slope"]) * self.sft.loc[i, "SFT.R.sq"],
+                str(self.sft.loc[i, "Power"]),
+                ha="center",
+                va="center",
+                color="black",
+                weight="bold",
+            )
+        ax[0].axhline(0.9, color="r")
         ax[0].set_xlabel("Soft Threshold (power)")
         ax[0].set_ylabel("Scale Free Topology Model Fit,signed R^2")
-        ax[0].title.set_text('Scale independence')
+        ax[0].title.set_text("Scale independence")
 
-        ax[1].plot(self.sft['Power'], self.sft['mean(k)'], 'o')
+        ax[1].plot(self.sft["Power"], self.sft["mean(k)"], "o")
         for i in range(len(self.powers)):
-            ax[1].text(self.sft.loc[i, 'Power'], self.sft.loc[i, 'mean(k)'],
-                       str(self.sft.loc[i, 'Power']), ha="center", va="center", color='r', weight='bold')
+            ax[1].text(
+                self.sft.loc[i, "Power"],
+                self.sft.loc[i, "mean(k)"],
+                str(self.sft.loc[i, "Power"]),
+                ha="center",
+                va="center",
+                color="r",
+                weight="bold",
+            )
         ax[1].set_xlabel("Soft Threshold (power)")
         ax[1].set_ylabel("Mean Connectivity")
-        ax[1].title.set_text('Mean connectivity')
+        ax[1].title.set_text("Mean connectivity")
 
         fig.tight_layout()
         if self.save:
-            fig.savefig(f"{self.outputPath}figures/{self.name}_summary_power.{self.figureType}", \
-                        bbox_inches='tight')
+            fig.savefig(
+                f"{self.outputPath}figures/{self.name}_summary_power.{self.figureType}",
+                bbox_inches="tight",
+            )
 
         # Set Power
         kwargs = dict()
-        if 'adjacency' in list(kwargs_function.keys()):
-            kwargs = kwargs_function['adjacency']
-        self.adjacency = WGCNA.adjacency(self.datExpr.to_df(), power=self.power, adjacencyType=self.networkType,
-                                         **kwargs)
-        self.adjacency = pd.DataFrame(self.adjacency,
-                                      columns=self.datExpr.to_df().columns,
-                                      index=self.datExpr.to_df().columns)
+        if "adjacency" in list(kwargs_function.keys()):
+            kwargs = kwargs_function["adjacency"]
+        self.adjacency = WGCNA.adjacency(
+            self.datExpr.to_df(),
+            power=self.power,
+            adjacencyType=self.networkType,
+            **kwargs,
+        )
+        self.adjacency = pd.DataFrame(
+            self.adjacency,
+            columns=self.datExpr.to_df().columns,
+            index=self.datExpr.to_df().columns,
+        )
 
         # Turn adjacency into topological overlap
         kwargs = dict()
-        if 'TOMsimilarity' in list(kwargs_function.keys()):
-            kwargs = kwargs_function['TOMsimilarity']
-        self.TOM = WGCNA.TOMsimilarity(self.adjacency.to_numpy(), TOMType=self.TOMType, **kwargs)
+        if "TOMsimilarity" in list(kwargs_function.keys()):
+            kwargs = kwargs_function["TOMsimilarity"]
+        self.TOM = WGCNA.TOMsimilarity(
+            self.adjacency.to_numpy(), TOMType=self.TOMType, **kwargs
+        )
         self.TOM.columns = self.datExpr.to_df().columns
         self.TOM.index = self.datExpr.to_df().columns
         dissTOM = 1 - self.TOM
@@ -329,76 +405,106 @@ class WGCNA(GeneExp):
 
         # Module identification using dynamic tree cut
         kwargs = dict()
-        if 'cutreeHybrid' in list(kwargs_function.keys()):
-            kwargs = kwargs_function['cutreeHybrid']
-        dynamicMods = WGCNA.cutreeHybrid(dendro=self.geneTree, distM=dissTOM, minClusterSize=self.minModuleSize,
-                                         **kwargs)
+        if "cutreeHybrid" in list(kwargs_function.keys()):
+            kwargs = kwargs_function["cutreeHybrid"]
+        dynamicMods = WGCNA.cutreeHybrid(
+            dendro=self.geneTree,
+            distM=dissTOM,
+            minClusterSize=self.minModuleSize,
+            **kwargs,
+        )
 
         # Convert numeric labels into colors
         kwargs = dict()
-        if 'labels2colors' in list(kwargs_function.keys()):
-            kwargs = kwargs_function['labels2colors']
-        self.datExpr.var['dynamicColors'] = WGCNA.labels2colors(labels=dynamicMods, **kwargs)
+        if "labels2colors" in list(kwargs_function.keys()):
+            kwargs = kwargs_function["labels2colors"]
+        self.datExpr.var["dynamicColors"] = WGCNA.labels2colors(
+            labels=dynamicMods, **kwargs
+        )
 
         # Calculate eigengenes
         kwargs = dict()
-        if 'moduleEigengenes' in list(kwargs_function.keys()):
-            kwargs = kwargs_function['moduleEigengenes']
-        MEList = WGCNA.moduleEigengenes(expr=self.datExpr.to_df(), colors=self.datExpr.var['dynamicColors'], **kwargs)
+        if "moduleEigengenes" in list(kwargs_function.keys()):
+            kwargs = kwargs_function["moduleEigengenes"]
+        MEList = WGCNA.moduleEigengenes(
+            expr=self.datExpr.to_df(),
+            colors=self.datExpr.var["dynamicColors"],
+            **kwargs,
+        )
 
-        self.MEs = MEList['eigengenes']
-        if 'MEgrey' in self.MEs.columns:
-            self.MEs.drop(['MEgrey'], axis=1, inplace=True)
+        self.MEs = MEList["eigengenes"]
+        if "MEgrey" in self.MEs.columns:
+            self.MEs.drop(["MEgrey"], axis=1, inplace=True)
         # Calculate dissimilarity of module eigengenes
-        MEDiss = pd.DataFrame(1 - np.corrcoef(self.MEs, rowvar=False), index=self.MEs.columns, columns=self.MEs.columns)
+        MEDiss = pd.DataFrame(
+            1 - np.corrcoef(self.MEs, rowvar=False),
+            index=self.MEs.columns,
+            columns=self.MEs.columns,
+        )
         if MEDiss.shape != (1, 1):
             # Cluster module eigengenes
             a = squareform(MEDiss, checks=False)
 
             METree = WGCNA.hclust(a, method="average")
 
-            plt.figure(figsize=(max(20, round(MEDiss.shape[1] / 20)), 10), facecolor='white')
-            dendrogram(METree, color_threshold=self.MEDissThres, labels=MEDiss.columns, leaf_rotation=90,
-                       leaf_font_size=8)
-            plt.axhline(y=self.MEDissThres, c='grey', lw=1, linestyle='dashed')
-            plt.title('Clustering of module eigengenes')
-            plt.xlabel('')
-            plt.ylabel('')
+            plt.figure(
+                figsize=(max(20, round(MEDiss.shape[1] / 20)), 10), facecolor="white"
+            )
+            dendrogram(
+                METree,
+                color_threshold=self.MEDissThres,
+                labels=MEDiss.columns,
+                leaf_rotation=90,
+                leaf_font_size=8,
+            )
+            plt.axhline(y=self.MEDissThres, c="grey", lw=1, linestyle="dashed")
+            plt.title("Clustering of module eigengenes")
+            plt.xlabel("")
+            plt.ylabel("")
             plt.tight_layout()
             if self.save:
-                plt.savefig(f"{self.outputPath}figures/{self.name}_eigenesgenes.{self.figureType}", \
-                            bbox_inches='tight')
+                plt.savefig(
+                    f"{self.outputPath}figures/{self.name}_eigenesgenes.{self.figureType}",
+                    bbox_inches="tight",
+                )
 
             # Call an automatic merging function
             kwargs = dict()
-            if 'mergeCloseModules' in list(kwargs_function.keys()):
-                kwargs = kwargs_function['mergeCloseModules']
-            merge = WGCNA.mergeCloseModules(self.datExpr.to_df(), self.datExpr.var['dynamicColors'],
-                                            cutHeight=self.MEDissThres, **kwargs)
+            if "mergeCloseModules" in list(kwargs_function.keys()):
+                kwargs = kwargs_function["mergeCloseModules"]
+            merge = WGCNA.mergeCloseModules(
+                self.datExpr.to_df(),
+                self.datExpr.var["dynamicColors"],
+                cutHeight=self.MEDissThres,
+                **kwargs,
+            )
             # The merged module colors; Rename to moduleColors
-            self.datExpr.var['moduleColors'] = merge['colors']
+            self.datExpr.var["moduleColors"] = merge["colors"]
         else:
-            self.datExpr.var['moduleColors'] = ["black"] * self.datExpr.shape[1]
+            self.datExpr.var["moduleColors"] = ["black"] * self.datExpr.shape[1]
 
         # Construct numerical labels corresponding to the colors
-        colorOrder = np.unique(self.datExpr.var['moduleColors']).tolist()
-        self.datExpr.var['moduleLabels'] = [colorOrder.index(x) if x in colorOrder else None for x in
-                                            self.datExpr.var['moduleColors']]
+        colorOrder = np.unique(self.datExpr.var["moduleColors"]).tolist()
+        self.datExpr.var["moduleLabels"] = [
+            colorOrder.index(x) if x in colorOrder else None
+            for x in self.datExpr.var["moduleColors"]
+        ]
         # Eigengenes of the new merged modules:
-        self.MEs = merge['newMEs']
+        self.MEs = merge["newMEs"]
 
         # Recalculate MEs with color labels
         kwargs = dict()
-        if 'moduleEigengenes' in list(kwargs_function.keys()):
-            kwargs = kwargs_function['moduleEigengenes']
-        self.datME = WGCNA.moduleEigengenes(self.datExpr.to_df(), self.datExpr.var['moduleColors'], **kwargs)[
-            'eigengenes']
-        if 'MEgrey' in self.datME.columns:
-            self.datME.drop(['MEgrey'], axis=1, inplace=True)
+        if "moduleEigengenes" in list(kwargs_function.keys()):
+            kwargs = kwargs_function["moduleEigengenes"]
+        self.datME = WGCNA.moduleEigengenes(
+            self.datExpr.to_df(), self.datExpr.var["moduleColors"], **kwargs
+        )["eigengenes"]
+        if "MEgrey" in self.datME.columns:
+            self.datME.drop(["MEgrey"], axis=1, inplace=True)
 
         kwargs = dict()
-        if 'orderMEs' in list(kwargs_function.keys()):
-            kwargs = kwargs_function['orderMEs']
+        if "orderMEs" in list(kwargs_function.keys()):
+            kwargs = kwargs_function["orderMEs"]
         self.MEs = WGCNA.orderMEs(self.datME, **kwargs)
 
         print("\tDone running WGCNA..\n")
@@ -413,7 +519,9 @@ class WGCNA(GeneExp):
 
         return self
 
-    def analyseWGCNA(self, order=None, geneList=None, show=True, alternative='two-sided'):
+    def analyseWGCNA(
+        self, order=None, geneList=None, show=True, alternative="two-sided"
+    ):
         """
         Analysing results: 1.calculating module trait relationship 2.plotting module heatmap eigengene 3.finding GO term for each module
 
@@ -430,18 +538,24 @@ class WGCNA(GeneExp):
 
         print(f"{OKCYAN}Calculating module trait relationship ...{ENDC}")
 
-        self.module_trait_relationships_heatmap(metaData=self.datExpr.obs.columns.tolist(),
-                                                alternative=alternative,
-                                                show=show,
-                                                file_name=f'{self.name}_module-traitRelationships')
+        self.module_trait_relationships_heatmap(
+            metaData=self.datExpr.obs.columns.tolist(),
+            alternative=alternative,
+            show=show,
+            file_name=f"{self.name}_module-traitRelationships",
+        )
         print("\tDone..\n")
 
-        print(f"{OKCYAN}Adding (signed) eigengene-based connectivity (module membership) ...{ENDC}")
+        print(
+            f"{OKCYAN}Adding (signed) eigengene-based connectivity (module membership) ...{ENDC}"
+        )
         self.CalculateSignedKME()
         print("\tDone..\n")
 
         if geneList is not None:
-            print(f"{OKCYAN}Updating gene information based on given gene list ...{ENDC}")
+            print(
+                f"{OKCYAN}Updating gene information based on given gene list ...{ENDC}"
+            )
             self.updateGeneInfo(geneInfo=geneList)
             print("\tDone..\n")
 
@@ -464,21 +578,24 @@ class WGCNA(GeneExp):
             print(f"{OKCYAN}plotting module barplot eigengene...{ENDC}")
             if self.datExpr.obs.shape[1] == 0:
                 print(
-                    f"{WARNING}There is not any sample information in given object! Skip running barplotModuleEigenGene() function.{ENDC}")
+                    f"{WARNING}There is not any sample information in given object! Skip running barplotModuleEigenGene() function.{ENDC}"
+                )
             else:
                 for module in modules:
-                    self.barplotModuleEigenGene(module, metadata, colorBar=metadata[-1], show=show)
+                    self.barplotModuleEigenGene(
+                        module, metadata, colorBar=metadata[-1], show=show
+                    )
                 print("\tDone..\n")
 
         if self.save:
             print(f"{OKCYAN}doing Enrichr GO analysis for each module...{ENDC}")
-            if 'gene_name' not in self.datExpr.var.columns:
+            if "gene_name" not in self.datExpr.var.columns:
                 print(
-                    f"{WARNING}\tgene name didn't found in gene information!\n\t Go term analysis can not be done{ENDC}")
+                    f"{WARNING}\tgene name didn't found in gene information!\n\t Go term analysis can not be done{ENDC}"
+                )
             else:
                 for module in modules:
-                    self.functional_enrichment_analysis(type="GO",
-                                                        moduleName=module)
+                    self.functional_enrichment_analysis(type="GO", moduleName=module)
             print("\tDone..\n")
 
     @staticmethod
@@ -523,13 +640,17 @@ class WGCNA(GeneExp):
 
         weights = np.asmatrix(weights)
         if expr.shape != weights.shape:
-            sys.exit("When 'weights' are given, they must have the same dimensions as 'expr'.")
+            sys.exit(
+                "When 'weights' are given, they must have the same dimensions as 'expr'."
+            )
         if (weights < 0).any():
             sys.exit("Found negative weights. All weights must be non-negative.")
 
         nf = np.isinf(weights)
         if any(nf):
-            print(f"{WARNING}Found non-finite weights. The corresponding data points will be removed.{ENDC}")
+            print(
+                f"{WARNING}Found non-finite weights. The corresponding data points will be removed.{ENDC}"
+            )
             weights[nf] = None
 
         if scaleByMax:
@@ -541,8 +662,15 @@ class WGCNA(GeneExp):
 
     # Check that all genes and samples have sufficiently low numbers of missing values.
     @staticmethod
-    def goodSamplesGenes(datExpr, weights=None, minFraction=1 / 2, minNSamples=4, minNGenes=4, tol=None,
-                         minRelativeWeight=0.1):
+    def goodSamplesGenes(
+        datExpr,
+        weights=None,
+        minFraction=1 / 2,
+        minNSamples=4,
+        minNGenes=4,
+        tol=None,
+        minRelativeWeight=0.1,
+    ):
         """
         Checks data for missing entries, entries with weights below a threshold, and zero-variance genes. If necessary, the filtering is iterated.
 
@@ -570,29 +698,56 @@ class WGCNA(GeneExp):
         nBadSamples = 0
         changed = True
         iter = 1
-        print("\tDetecting genes and samples with too many missing values...", flush=True)
+        print(
+            "\tDetecting genes and samples with too many missing values...", flush=True
+        )
         while changed:
-            goodGenes = WGCNA.goodGenesFun(datExpr, weights, goodSamples, goodGenes, minFraction=minFraction,
-                                           minNSamples=minNSamples, minNGenes=minNGenes,
-                                           minRelativeWeight=minRelativeWeight,
-                                           tol=tol)
-            goodSamples = WGCNA.goodSamplesFun(datExpr, weights, goodSamples, goodGenes, minFraction=minFraction,
-                                               minNSamples=minNSamples, minNGenes=minNGenes,
-                                               minRelativeWeight=minRelativeWeight)
-            changed = np.logical_or((np.logical_not(goodGenes).sum() > nBadGenes),
-                                    (np.logical_not(goodSamples).sum() > nBadSamples))
+            goodGenes = WGCNA.goodGenesFun(
+                datExpr,
+                weights,
+                goodSamples,
+                goodGenes,
+                minFraction=minFraction,
+                minNSamples=minNSamples,
+                minNGenes=minNGenes,
+                minRelativeWeight=minRelativeWeight,
+                tol=tol,
+            )
+            goodSamples = WGCNA.goodSamplesFun(
+                datExpr,
+                weights,
+                goodSamples,
+                goodGenes,
+                minFraction=minFraction,
+                minNSamples=minNSamples,
+                minNGenes=minNGenes,
+                minRelativeWeight=minRelativeWeight,
+            )
+            changed = np.logical_or(
+                (np.logical_not(goodGenes).sum() > nBadGenes),
+                (np.logical_not(goodSamples).sum() > nBadSamples),
+            )
             nBadGenes = np.logical_not(goodGenes).sum()
             nBadSamples = np.logical_not(goodSamples).sum()
             iter = iter + 1
 
-        allOK = (nBadGenes + nBadSamples == 0)
+        allOK = nBadGenes + nBadSamples == 0
 
         return goodGenes, goodSamples, allOK
 
     # Filter genes with too many missing entries
     @staticmethod
-    def goodGenesFun(datExpr, weights=None, useSamples=None, useGenes=None, minFraction=1 / 2,
-                     minNSamples=4, minNGenes=4, tol=None, minRelativeWeight=0.1):
+    def goodGenesFun(
+        datExpr,
+        weights=None,
+        useSamples=None,
+        useGenes=None,
+        minFraction=1 / 2,
+        minNSamples=4,
+        minNGenes=4,
+        tol=None,
+        minRelativeWeight=0.1,
+    ):
         """
         Check data for missing entries and returns a list of genes that have non-zero variance
 
@@ -618,7 +773,9 @@ class WGCNA(GeneExp):
         :return: A logical list with one entry per gene that is TRUE if the gene is considered good and FALSE otherwise. Note that all genes excluded by useGenes are automatically assigned FALSE.
         :rtype: list of bool
         """
-        if not datExpr.apply(lambda s: pd.to_numeric(s, errors='coerce').notnull().all()).all():
+        if not datExpr.apply(
+            lambda s: pd.to_numeric(s, errors="coerce").notnull().all()
+        ).all():
             sys.exit("datExpr must contain numeric data.")
 
         weights = WGCNA.checkAndScaleWeights(weights, datExpr, scaleByMax=True)
@@ -631,17 +788,23 @@ class WGCNA(GeneExp):
             useSamples = np.repeat(True, datExpr.shape[1])
 
         if len(useGenes) != datExpr.shape[0]:
-            sys.exit("Length of nGenes is not compatible with number of columns in datExpr.")
+            sys.exit(
+                "Length of nGenes is not compatible with number of columns in datExpr."
+            )
         if len(useSamples) != datExpr.shape[1]:
-            sys.exit("Length of nSamples is not compatible with number of rows in datExpr.")
+            sys.exit(
+                "Length of nSamples is not compatible with number of rows in datExpr."
+            )
 
         nSamples = sum(useSamples)
         nGenes = sum(useGenes)
         if weights is None:
             nPresent = datExpr.loc[useGenes, useSamples].notna().sum(axis=1)
         else:
-            nPresent = (datExpr.loc[useGenes, useSamples].notna() and
-                        weights.loc[useGenes, useSamples] > minRelativeWeight).sum(axis=1)
+            nPresent = (
+                datExpr.loc[useGenes, useSamples].notna()
+                and weights.loc[useGenes, useSamples] > minRelativeWeight
+            ).sum(axis=1)
 
         gg = useGenes.copy()
         if len(useGenes) != len(nPresent):
@@ -666,21 +829,37 @@ class WGCNA(GeneExp):
 
         var[pd.isnull(var)] = 0
         nNAsGenes = datExpr.loc[gg, useSamples].isna().sum(axis=1)
-        gg[gg] = np.logical_and(np.logical_and(nNAsGenes < (1 - minFraction) * nSamples, var > tol ** 2),
-                                nSamples - nNAsGenes >= minNSamples)
+        gg[gg] = np.logical_and(
+            np.logical_and(nNAsGenes < (1 - minFraction) * nSamples, var > tol**2),
+            nSamples - nNAsGenes >= minNSamples,
+        )
 
         if sum(gg) < minNGenes:
-            sys.exit("Too few genes with valid expression levels in the required number of samples.")
+            sys.exit(
+                "Too few genes with valid expression levels in the required number of samples."
+            )
         if nGenes - sum(gg) > 0:
-            print("\n\n  ..Excluding", nGenes - sum(gg),
-                  "genes from the calculation due to too many missing samples or zero variance.\n\n", flush=True)
+            print(
+                "\n\n  ..Excluding",
+                nGenes - sum(gg),
+                "genes from the calculation due to too many missing samples or zero variance.\n\n",
+                flush=True,
+            )
 
         return gg
 
     # Filter samples with too many missing entries
     @staticmethod
-    def goodSamplesFun(datExpr, weights=None, useSamples=None, useGenes=None, minFraction=1 / 2,
-                       minNSamples=4, minNGenes=4, minRelativeWeight=0.1):
+    def goodSamplesFun(
+        datExpr,
+        weights=None,
+        useSamples=None,
+        useGenes=None,
+        minFraction=1 / 2,
+        minNSamples=4,
+        minNGenes=4,
+        minRelativeWeight=0.1,
+    ):
         """
         Check data for missing entries and returns a list of samples that have non-zero variance
 
@@ -711,10 +890,14 @@ class WGCNA(GeneExp):
             useSamples = np.repeat(True, datExpr.shape[1])
 
         if len(useGenes) != datExpr.shape[0]:
-            sys.exit("Length of nGenes is not compatible with number of columns in datExpr.")
+            sys.exit(
+                "Length of nGenes is not compatible with number of columns in datExpr."
+            )
 
         if len(useSamples) != datExpr.shape[1]:
-            sys.exit("Length of nSamples is not compatible with number of rows in datExpr.")
+            sys.exit(
+                "Length of nSamples is not compatible with number of rows in datExpr."
+            )
 
         weights = WGCNA.checkAndScaleWeights(weights, datExpr, scaleByMax=True)
         nSamples = sum(useSamples)
@@ -722,21 +905,34 @@ class WGCNA(GeneExp):
         if weights is None:
             nNAsSamples = np.sum((datExpr.loc[useGenes, useSamples]).isnull(), axis=0)
         else:
-            nNAsSamples = np.sum(np.logical_or(datExpr[useGenes, useSamples],
-                                               WGCNA.replaceMissing(weights[useGenes, useSamples] < minRelativeWeight,
-                                                                    True))
-                                 .isnull(), axis=0)
+            nNAsSamples = np.sum(
+                np.logical_or(
+                    datExpr[useGenes, useSamples],
+                    WGCNA.replaceMissing(
+                        weights[useGenes, useSamples] < minRelativeWeight, True
+                    ),
+                ).isnull(),
+                axis=0,
+            )
 
         goodSamples = useSamples
-        goodSamples[useSamples] = np.logical_and((nNAsSamples < (1 - minFraction) * nGenes),
-                                                 (nGenes - nNAsSamples >= minNGenes))
+        goodSamples[useSamples] = np.logical_and(
+            (nNAsSamples < (1 - minFraction) * nGenes),
+            (nGenes - nNAsSamples >= minNGenes),
+        )
 
         if sum(goodSamples) < minNSamples:
-            sys.exit("Too few samples with valid expression levels for the required number of genes.")
+            sys.exit(
+                "Too few samples with valid expression levels for the required number of genes."
+            )
 
         if nSamples - sum(goodSamples) > 0:
-            print("  ..Excluding", nSamples - sum(goodSamples),
-                  "samples from the calculation due to too many missing genes.", flush=True)
+            print(
+                "  ..Excluding",
+                nSamples - sum(goodSamples),
+                "samples from the calculation due to too many missing genes.",
+                flush=True,
+            )
 
         return goodSamples
 
@@ -785,9 +981,20 @@ class WGCNA(GeneExp):
 
     # Call the network topology analysis function
     @staticmethod
-    def pickSoftThreshold(data, dataIsExpr=True, weights=None, RsquaredCut=0.9, MeanCut=100, powerVector=None,
-                          nBreaks=10, blockSize=None, corOptions=None, networkType="unsigned",
-                          moreNetworkConcepts=False, gcInterval=None):
+    def pickSoftThreshold(
+        data,
+        dataIsExpr=True,
+        weights=None,
+        RsquaredCut=0.9,
+        MeanCut=100,
+        powerVector=None,
+        nBreaks=10,
+        blockSize=None,
+        corOptions=None,
+        networkType="unsigned",
+        moreNetworkConcepts=False,
+        gcInterval=None,
+    ):
         """
         Analysis of scale free topology for multiple soft thresholding powers.
 
@@ -824,14 +1031,20 @@ class WGCNA(GeneExp):
         powerVector = np.sort(powerVector)
         intType = networkTypes.index(networkType)
         if intType is None:
-            sys.exit(("Unrecognized 'networkType'. Recognized values are", str(networkTypes)))
+            sys.exit(
+                ("Unrecognized 'networkType'. Recognized values are", str(networkTypes))
+            )
 
         nGenes = data.shape[1]
         if nGenes < 3:
-            sys.exit("The input data data contain fewer than 3 rows (nodes).\n"
-                     "This would result in a trivial correlation network.")
+            sys.exit(
+                "The input data data contain fewer than 3 rows (nodes).\n"
+                "This would result in a trivial correlation network."
+            )
 
-        print(f"{OKCYAN}pickSoftThreshold: calculating connectivity for given powers...{ENDC}")
+        print(
+            f"{OKCYAN}pickSoftThreshold: calculating connectivity for given powers...{ENDC}"
+        )
 
         if not dataIsExpr:
             WGCNA.checkSimilarity(data)
@@ -839,19 +1052,33 @@ class WGCNA(GeneExp):
                 data = np.where(np.diag(data), 1)
 
         if blockSize is None:
-            blockSize = WGCNA.calBlockSize(nGenes, rectangularBlocks=True, maxMemoryAllocation=2 ** 30)
+            blockSize = WGCNA.calBlockSize(
+                nGenes, rectangularBlocks=True, maxMemoryAllocation=2**30
+            )
             print("will use block size ", blockSize, flush=True)
 
         if gcInterval is None or len(gcInterval) == 0:
             gcInterval = 4 * blockSize
 
-        colname1 = ["Power", "SFT.R.sq", "slope", "truncated R.sq", "mean(k)", "median(k)", "max(k)"]
+        colname1 = [
+            "Power",
+            "SFT.R.sq",
+            "slope",
+            "truncated R.sq",
+            "mean(k)",
+            "median(k)",
+            "max(k)",
+        ]
 
         if moreNetworkConcepts:
             colname1 = colname1.append(["Density", "Centralization", "Heterogeneity"])
 
-        datout = pd.DataFrame(np.full((len(powerVector), len(colname1)), 666), columns=colname1, dtype=object)
-        datout['Power'] = powerVector
+        datout = pd.DataFrame(
+            np.full((len(powerVector), len(colname1)), 666),
+            columns=colname1,
+            dtype=object,
+        )
+        datout["Power"] = powerVector
 
         datk = np.zeros((nGenes, len(powerVector)))
         nPowers = len(powerVector)
@@ -859,16 +1086,20 @@ class WGCNA(GeneExp):
         lastGC = 0
         if corOptions is None:
             corOptions = pd.DataFrame()
-            corOptions['x'] = [data]
+            corOptions["x"] = [data]
         else:
-            corOptions['x'] = [data]
+            corOptions["x"] = [data]
 
         if weights is not None:
             if not dataIsExpr:
-                sys.exit("Weights can only be used when 'data' represents expression data ('dataIsExpr' must be TRUE).")
+                sys.exit(
+                    "Weights can only be used when 'data' represents expression data ('dataIsExpr' must be TRUE)."
+                )
             if data.shape != weights.shape:
-                sys.exit("When 'weights' are given, dimensions of 'data' and 'weights' must be the same.")
-            corOptions['weights.x'] = weights
+                sys.exit(
+                    "When 'weights' are given, dimensions of 'data' and 'weights' must be the same."
+                )
+            corOptions["weights.x"] = weights
 
         while startG < nGenes:
             endG = min(startG + blockSize, nGenes)
@@ -876,11 +1107,11 @@ class WGCNA(GeneExp):
             useGenes = list(range(startG, endG))
             nGenes1 = len(useGenes)
             if dataIsExpr:
-                corOptions['y'] = [data.iloc[:, useGenes]]
+                corOptions["y"] = [data.iloc[:, useGenes]]
                 if weights is not None:
-                    corOptions['weights.y'] = [weights.iloc[:, useGenes]]
+                    corOptions["weights.y"] = [weights.iloc[:, useGenes]]
                 corx = np.corrcoef(corOptions.x[0], corOptions.y[0], rowvar=False)
-                corx = corx[0:corOptions.x[0].shape[1], useGenes]
+                corx = corx[0 : corOptions.x[0].shape[1], useGenes]
                 if intType == 0:
                     corx = abs(corx)
                 elif intType == 1:
@@ -890,7 +1121,8 @@ class WGCNA(GeneExp):
 
                 if np.count_nonzero(np.isnan(corx)) != 0:
                     print(
-                        f"{WARNING}Some correlations are NA in block {str(startG)} : {str(endG)}.{ENDC}")
+                        f"{WARNING}Some correlations are NA in block {str(startG)} : {str(endG)}.{ENDC}"
+                    )
             else:
                 corx = data.iloc[:, useGenes].to_numpy()
 
@@ -904,7 +1136,7 @@ class WGCNA(GeneExp):
             uniquePowerSteps = np.unique(powerSteps)
 
             def func(power):
-                return corx ** power
+                return corx**power
 
             corxPowers = pd.DataFrame()
             for p in uniquePowerSteps:
@@ -924,33 +1156,45 @@ class WGCNA(GeneExp):
         for i in range(len(powerVector)):
             khelp = datk[:, i]
             SFT1 = WGCNA.scaleFreeFitIndex(k=khelp, nBreaks=nBreaks)
-            datout.loc[i, 'SFT.R.sq'] = SFT1.loc[0, 'Rsquared.SFT']
-            datout.loc[i, 'slope'] = SFT1.loc[0, 'slope.SFT']
-            datout.loc[i, 'truncated R.sq'] = SFT1.loc[0, 'truncatedExponentialAdjRsquared']
-            datout.loc[i, 'mean(k)'] = statistics.mean(khelp)
-            datout.loc[i, 'median(k)'] = statistics.median(khelp)
-            datout.loc[i, 'max(k)'] = max(khelp)
+            datout.loc[i, "SFT.R.sq"] = SFT1.loc[0, "Rsquared.SFT"]
+            datout.loc[i, "slope"] = SFT1.loc[0, "slope.SFT"]
+            datout.loc[i, "truncated R.sq"] = SFT1.loc[
+                0, "truncatedExponentialAdjRsquared"
+            ]
+            datout.loc[i, "mean(k)"] = statistics.mean(khelp)
+            datout.loc[i, "median(k)"] = statistics.median(khelp)
+            datout.loc[i, "max(k)"] = max(khelp)
 
             if moreNetworkConcepts:
                 Density = sum(khelp) / (nGenes * (nGenes - 1))
-                datout.loc[i, 'Density'] = Density
-                Centralization = nGenes * (max(khelp) - statistics.mean(khelp)) / ((nGenes - 1) * (nGenes - 2))
-                datout.loc[i, 'Centralization'] = Centralization
+                datout.loc[i, "Density"] = Density
+                Centralization = (
+                    nGenes
+                    * (max(khelp) - statistics.mean(khelp))
+                    / ((nGenes - 1) * (nGenes - 2))
+                )
+                datout.loc[i, "Centralization"] = Centralization
                 Heterogeneity = np.sqrt(nGenes * sum(khelp ^ 2) / sum(khelp) ^ 2 - 1)
-                datout.loc[i, 'Heterogeneity'] = Heterogeneity
+                datout.loc[i, "Heterogeneity"] = Heterogeneity
 
         print(datout)
 
         # detect threshold more than 0.9 by default
-        ind = np.logical_and(datout['SFT.R.sq'] > RsquaredCut, datout['mean(k)'] <= MeanCut)
+        ind = np.logical_and(
+            datout["SFT.R.sq"] > RsquaredCut, datout["mean(k)"] <= MeanCut
+        )
         if np.sum(ind) > 0:
             powerEstimate = np.min(powerVector[ind])
-            print(f"{OKGREEN}Selected power to have scale free network is {str(powerEstimate)}.{ENDC}")
+            print(
+                f"{OKGREEN}Selected power to have scale free network is {str(powerEstimate)}.{ENDC}"
+            )
         else:
-            ind = np.argsort(datout['SFT.R.sq']).tolist()
+            ind = np.argsort(datout["SFT.R.sq"]).tolist()
             powerEstimate = powerVector[ind[-1]]
-            print(f"{OKGREEN}No power detected to have scale free network!\nFound the best given power which is "
-                  f"{str(powerEstimate)}.{ENDC}")
+            print(
+                f"{OKGREEN}No power detected to have scale free network!\nFound the best given power which is "
+                f"{str(powerEstimate)}.{ENDC}"
+            )
 
         return powerEstimate, datout
 
@@ -985,7 +1229,9 @@ class WGCNA(GeneExp):
             sys.exit(f"some entries are not between {min} and {max}.")
 
     @staticmethod
-    def calBlockSize(matrixSize, rectangularBlocks=True, maxMemoryAllocation=None, overheadFactor=3):
+    def calBlockSize(
+        matrixSize, rectangularBlocks=True, maxMemoryAllocation=None, overheadFactor=3
+    ):
         """
         find suitable block size for calculating soft power threshold
         """
@@ -1014,38 +1260,51 @@ class WGCNA(GeneExp):
         :param nBreaks: (default = 10)
         :type nBreaks: int
         """
-        df = pd.DataFrame({'data': k})
-        df['discretized_k'] = pd.cut(df['data'], nBreaks)
-        dk = df.groupby('discretized_k').mean()  # tapply(k, discretized_k, mean)
+        df = pd.DataFrame({"data": k})
+        df["discretized_k"] = pd.cut(df["data"], nBreaks)
+        dk = df.groupby("discretized_k").mean()  # tapply(k, discretized_k, mean)
         dk = pd.DataFrame(dk.reset_index())
-        dk.columns = ['discretized_k', 'dk']
-        p_dk = df['discretized_k'].value_counts() / len(k)  # as.vector(tapply(k, discretized.k, length)/length(k))
+        dk.columns = ["discretized_k", "dk"]
+        p_dk = df["discretized_k"].value_counts() / len(
+            k
+        )  # as.vector(tapply(k, discretized.k, length)/length(k))
         p_dk = pd.DataFrame(p_dk.reset_index())
-        p_dk.columns = ['discretized_k', 'p_dk']
+        p_dk.columns = ["discretized_k", "p_dk"]
         breaks1 = np.linspace(start=min(k), stop=max(k), num=nBreaks + 1)
-        y, edges = np.histogram(df['data'], bins=breaks1)
+        y, edges = np.histogram(df["data"], bins=breaks1)
         dk2 = 0.5 * (edges[1:] + edges[:-1])
-        df = pd.merge(dk, p_dk, on='discretized_k')
-        if df['dk'].isnull().values.any():
-            df.loc[df['dk'].isnull().values, 'dk'] = dk2[df['dk'].isnull().values]
-        if np.any(df['dk'] == 0):
-            df.loc[df['dk'] == 0, 'dk'] = dk2[df['dk'] == 0]
-        if df['p_dk'].isnull().values.any():
-            df.loc[df['p_dk'].isnull().values, 'p_dk'] = 0
-        df['log_dk'] = np.log10(df['dk'])
-        df['log_p_dk'] = np.log10(df['p_dk'] + 1e-09)
-        df['log_p_dk_10'] = np.power(10, df['log_dk'])
+        df = pd.merge(dk, p_dk, on="discretized_k")
+        if df["dk"].isnull().values.any():
+            df.loc[df["dk"].isnull().values, "dk"] = dk2[df["dk"].isnull().values]
+        if np.any(df["dk"] == 0):
+            df.loc[df["dk"] == 0, "dk"] = dk2[df["dk"] == 0]
+        if df["p_dk"].isnull().values.any():
+            df.loc[df["p_dk"].isnull().values, "p_dk"] = 0
+        df["log_dk"] = np.log10(df["dk"])
+        df["log_p_dk"] = np.log10(df["p_dk"] + 1e-09)
+        df["log_p_dk_10"] = np.power(10, df["log_dk"])
 
-        model1 = ols(formula='log_p_dk ~ log_dk', data=df).fit()
-        model2 = ols(formula='log_p_dk ~ log_dk + log_p_dk_10', data=df).fit()
-        dfout = pd.DataFrame({'Rsquared.SFT': [model1.rsquared],
-                              'slope.SFT': [model1.params.values[1]],
-                              'truncatedExponentialAdjRsquared': [model2.rsquared_adj]})
+        model1 = ols(formula="log_p_dk ~ log_dk", data=df).fit()
+        model2 = ols(formula="log_p_dk ~ log_dk + log_p_dk_10", data=df).fit()
+        dfout = pd.DataFrame(
+            {
+                "Rsquared.SFT": [model1.rsquared],
+                "slope.SFT": [model1.params.values[1]],
+                "truncatedExponentialAdjRsquared": [model2.rsquared_adj],
+            }
+        )
         return dfout
 
     @staticmethod
-    def adjacency(datExpr, selectCols=None, adjacencyType="unsigned", power=6, corOptions=pd.DataFrame(), weights=None,
-                  weightArgNames=None):
+    def adjacency(
+        datExpr,
+        selectCols=None,
+        adjacencyType="unsigned",
+        power=6,
+        corOptions=pd.DataFrame(),
+        weights=None,
+        weightArgNames=None,
+    ):
         """
         Calculates (correlation or distance) network adjacency from given expression data or from a similarity
 
@@ -1072,21 +1331,30 @@ class WGCNA(GeneExp):
             weightArgNames = ["weights.x", "weights.y"]
         intType = adjacencyTypes.index(adjacencyType)
         if intType is None:
-            sys.exit(("Unrecognized 'type'. Recognized values are", str(adjacencyTypes)))
+            sys.exit(
+                ("Unrecognized 'type'. Recognized values are", str(adjacencyTypes))
+            )
         weights = WGCNA.checkAndScaleWeights(weights, datExpr, scaleByMax=False)
         if weights is not None:
             if selectCols is None:
                 if isinstance(corOptions, pd.DataFrame):
-                    weightOpt = pd.DataFrame({'weights.x': weights})
+                    weightOpt = pd.DataFrame({"weights.x": weights})
                     weightOpt.index = weightArgNames[0]
                 else:
                     weightOpt = weightArgNames[0] + " = weights"
             else:
                 if isinstance(corOptions, pd.DataFrame):
-                    weightOpt = pd.DataFrame({'weights.x': weights, 'weights.y': weights[:, selectCols]})
+                    weightOpt = pd.DataFrame(
+                        {"weights.x": weights, "weights.y": weights[:, selectCols]}
+                    )
                     weightOpt.index = weightArgNames[0:2]
                 else:
-                    weightOpt = weightArgNames[1] + " = weights, " + weightArgNames[2] + " = weights[, selectCols]"
+                    weightOpt = (
+                        weightArgNames[1]
+                        + " = weights, "
+                        + weightArgNames[2]
+                        + " = weights[, selectCols]"
+                    )
         else:
             if isinstance(corOptions, pd.DataFrame):
                 weightOpt = pd.DataFrame()
@@ -1095,9 +1363,12 @@ class WGCNA(GeneExp):
 
         if selectCols is None:
             cor_mat = np.corrcoef(
-                datExpr.T)  # cor_mat = do.call(corFnc.fnc, c(list(x = datExpr), weightOpt, corOptions))
+                datExpr.T
+            )  # cor_mat = do.call(corFnc.fnc, c(list(x = datExpr), weightOpt, corOptions))
         else:
-            cor_mat = np.corrcoef(x=datExpr, y=datExpr[:, selectCols])  # , weightOpt, corOptions)
+            cor_mat = np.corrcoef(
+                x=datExpr, y=datExpr[:, selectCols]
+            )  # , weightOpt, corOptions)
 
         if intType == 0:
             cor_mat = abs(cor_mat)
@@ -1108,7 +1379,7 @@ class WGCNA(GeneExp):
 
         print("\tDone..\n")
 
-        return cor_mat ** power
+        return cor_mat**power
 
     @staticmethod
     def checkAdjMat(adjMat, min=0, max=1):
@@ -1176,7 +1447,9 @@ class WGCNA(GeneExp):
             sys.exit(f"Invalid 'TOMType'. Recognized values are {', '.join(TOMTypes)}")
         TOMDenomC = TOMDenoms.index(TOMDenom)
         if TOMDenomC is None:
-            sys.exit(f"Invalid 'TOMDenom'. Recognized values are {', '.join(TOMDenoms)}")
+            sys.exit(
+                f"Invalid 'TOMDenom'. Recognized values are {', '.join(TOMDenoms)}"
+            )
 
         min = 0
         if TOMTypeC == 1:
@@ -1215,7 +1488,6 @@ class WGCNA(GeneExp):
 
     @staticmethod
     def get_heights(Z):
-
         clusternode = to_tree(Z, True)
         height = np.array([c.dist for c in clusternode[1] if c.is_leaf() is not True])
 
@@ -1237,14 +1509,30 @@ class WGCNA(GeneExp):
         return merges
 
     @staticmethod
-    def cutreeHybrid(dendro, distM, cutHeight=None, minClusterSize=20, deepSplit=1,
-                     maxCoreScatter=None, minGap=None, maxAbsCoreScatter=None,
-                     minAbsGap=None, minSplitHeight=None, minAbsSplitHeight=None,
-                     externalBranchSplitFnc=None, nExternalSplits=0, minExternalSplit=None,
-                     externalSplitOptions=pd.DataFrame(), externalSplitFncNeedsDistance=None,
-                     assumeSimpleExternalSpecification=True, pamStage=True,
-                     pamRespectsDendro=True, useMedoids=False, maxPamDist=None,
-                     respectSmallClusters=True):
+    def cutreeHybrid(
+        dendro,
+        distM,
+        cutHeight=None,
+        minClusterSize=20,
+        deepSplit=1,
+        maxCoreScatter=None,
+        minGap=None,
+        maxAbsCoreScatter=None,
+        minAbsGap=None,
+        minSplitHeight=None,
+        minAbsSplitHeight=None,
+        externalBranchSplitFnc=None,
+        nExternalSplits=0,
+        minExternalSplit=None,
+        externalSplitOptions=pd.DataFrame(),
+        externalSplitFncNeedsDistance=None,
+        assumeSimpleExternalSpecification=True,
+        pamStage=True,
+        pamRespectsDendro=True,
+        useMedoids=False,
+        maxPamDist=None,
+        respectSmallClusters=True,
+    ):
         """
         Detect clusters in a dendorgram produced by the function hclust.
 
@@ -1310,10 +1598,13 @@ class WGCNA(GeneExp):
         if distM.shape[0] != nMerge + 1 or distM.shape[1] != nMerge + 1:
             sys.exit("distM has incorrect dimensions.")
         if pamRespectsDendro and not respectSmallClusters:
-            print("cutreeHybrid Warning: parameters pamRespectsDendro (TRUE) "
-                  "and respectSmallClusters (FALSE) imply contradictory intent.\n"
-                  "Although the code will work, please check you really intented "
-                  "these settings for the two arguments.", flush=True)
+            print(
+                "cutreeHybrid Warning: parameters pamRespectsDendro (TRUE) "
+                "and respectSmallClusters (FALSE) imply contradictory intent.\n"
+                "Although the code will work, please check you really intented "
+                "these settings for the two arguments.",
+                flush=True,
+            )
 
         print(f"{OKCYAN}Going through the merge tree...{ENDC}")
 
@@ -1326,8 +1617,12 @@ class WGCNA(GeneExp):
         refHeight = dendro[refMerge, 2]
         if cutHeight is None:
             cutHeight = 0.99 * (np.max(dendro_height) - refHeight) + refHeight
-            print("..cutHeight not given, setting it to", round(cutHeight, 3),
-                  " ===>  99% of the (truncated) height range in dendro.", flush=True)
+            print(
+                "..cutHeight not given, setting it to",
+                round(cutHeight, 3),
+                " ===>  99% of the (truncated) height range in dendro.",
+                flush=True,
+            )
         else:
             if cutHeight > np.max(dendro_height):
                 cutHeight = np.max(dendro_height)
@@ -1336,7 +1631,7 @@ class WGCNA(GeneExp):
         nMergeBelowCut = np.count_nonzero(dendro_height <= cutHeight)
         if nMergeBelowCut < minClusterSize:
             print("cutHeight set too low: no merges below the cut.", flush=True)
-            return pd.DataFrame({'labels': np.repeat(0, nMerge + 1, axis=0)})
+            return pd.DataFrame({"labels": np.repeat(0, nMerge + 1, axis=0)})
 
         if externalBranchSplitFnc is not None:
             nExternalSplits = len(externalBranchSplitFnc)
@@ -1346,9 +1641,12 @@ class WGCNA(GeneExp):
                 externalSplitOptions = pd.DataFrame(externalSplitOptions)
             # TODO: externalBranchSplitFnc = lapply(externalBranchSplitFnc, match.fun)
             for es in range(nExternalSplits):
-                externalSplitOptions['tree'][es] = dendro
-                if len(externalSplitFncNeedsDistance) == 0 or externalSplitFncNeedsDistance[es]:
-                    externalSplitOptions['dissimMat'][es] = distM
+                externalSplitOptions["tree"][es] = dendro
+                if (
+                    len(externalSplitFncNeedsDistance) == 0
+                    or externalSplitFncNeedsDistance[es]
+                ):
+                    externalSplitOptions["dissimMat"][es] = distM
 
         MxBranches = nMergeBelowCut
         branch_isBasic = np.repeat(True, MxBranches, axis=0)
@@ -1373,8 +1671,12 @@ class WGCNA(GeneExp):
         if isinstance(deepSplit, bool):
             deepSplit = pd.to_numeric(deepSplit) * (nSplitDefaults - 2)
         if deepSplit < 0 or deepSplit > nSplitDefaults:
-            msg = "Parameter deepSplit (value" + str(deepSplit) + \
-                  ") out of range: allowable range is 0 through", str(nSplitDefaults - 1)
+            msg = (
+                "Parameter deepSplit (value"
+                + str(deepSplit)
+                + ") out of range: allowable range is 0 through",
+                str(nSplitDefaults - 1),
+            )
             sys.exit(msg)
         if maxCoreScatter is None:
             maxCoreScatter = WGCNA.interpolate(defMCS, deepSplit)
@@ -1393,17 +1695,23 @@ class WGCNA(GeneExp):
         onBranch = np.repeat(0, nPoints, axis=0)
         RootBranch = 0
 
-        mergeDiagnostics = pd.DataFrame({'smI': np.repeat(np.nan, nMerge, axis=0),
-                                         'smSize': np.repeat(np.nan, nMerge, axis=0),
-                                         'smCrSc': np.repeat(np.nan, nMerge, axis=0),
-                                         'smGap': np.repeat(np.nan, nMerge, axis=0),
-                                         'lgI': np.repeat(np.nan, nMerge, axis=0),
-                                         'lgSize': np.repeat(np.nan, nMerge, axis=0),
-                                         'lgCrSc': np.repeat(np.nan, nMerge, axis=0),
-                                         'lgGap': np.repeat(np.nan, nMerge, axis=0),
-                                         'merged': np.repeat(np.nan, nMerge, axis=0)})
+        mergeDiagnostics = pd.DataFrame(
+            {
+                "smI": np.repeat(np.nan, nMerge, axis=0),
+                "smSize": np.repeat(np.nan, nMerge, axis=0),
+                "smCrSc": np.repeat(np.nan, nMerge, axis=0),
+                "smGap": np.repeat(np.nan, nMerge, axis=0),
+                "lgI": np.repeat(np.nan, nMerge, axis=0),
+                "lgSize": np.repeat(np.nan, nMerge, axis=0),
+                "lgCrSc": np.repeat(np.nan, nMerge, axis=0),
+                "lgGap": np.repeat(np.nan, nMerge, axis=0),
+                "merged": np.repeat(np.nan, nMerge, axis=0),
+            }
+        )
         if externalBranchSplitFnc is not None:
-            externalMergeDiags = pd.DataFrame(np.nan, index=list(range(nMerge)), columns=list(range(nExternalSplits)))
+            externalMergeDiags = pd.DataFrame(
+                np.nan, index=list(range(nMerge)), columns=list(range(nExternalSplits))
+            )
 
         extender = np.repeat(0, chunkSize, axis=0)
 
@@ -1413,17 +1721,28 @@ class WGCNA(GeneExp):
                     nBranches = nBranches + 1
                     branch_isBasic[nBranches - 1] = True
                     branch_isTopBasic[nBranches - 1] = True
-                    branch_singletons[nBranches - 1] = np.append(-1 * dendro_merge[merge, :], extender)
+                    branch_singletons[nBranches - 1] = np.append(
+                        -1 * dendro_merge[merge, :], extender
+                    )
                     branch_basicClusters[nBranches - 1] = extender
-                    branch_mergingHeights[nBranches - 1] = np.append(np.repeat(dendro_height[merge], 2), extender)
-                    branch_singletonHeights[nBranches - 1] = np.append(np.repeat(dendro_height[merge], 2), extender)
+                    branch_mergingHeights[nBranches - 1] = np.append(
+                        np.repeat(dendro_height[merge], 2), extender
+                    )
+                    branch_singletonHeights[nBranches - 1] = np.append(
+                        np.repeat(dendro_height[merge], 2), extender
+                    )
                     IndMergeToBranch[merge] = nBranches
                     RootBranch = nBranches
-                elif np.sign(dendro_merge[merge, 0]) * np.sign(dendro_merge[merge, 1]) < 0:
+                elif (
+                    np.sign(dendro_merge[merge, 0]) * np.sign(dendro_merge[merge, 1])
+                    < 0
+                ):
                     clust = IndMergeToBranch[int(np.max(dendro_merge[merge, :])) - 1]
 
                     if clust == 0:
-                        sys.exit("Internal error: a previous merge has no associated cluster. Sorry!")
+                        sys.exit(
+                            "Internal error: a previous merge has no associated cluster. Sorry!"
+                        )
 
                     gene = -1 * int(np.min(dendro_merge[merge, :]))
                     ns = branch_nSingletons[clust - 1] + 1
@@ -1431,15 +1750,23 @@ class WGCNA(GeneExp):
 
                     if branch_isBasic[clust - 1]:
                         if ns > len(branch_singletons[clust - 1]):
-                            branch_singletons[clust - 1] = np.append(branch_singletons[clust - 1], extender)
-                            branch_singletonHeights[clust - 1] = np.append(branch_singletonHeights[clust - 1], extender)
+                            branch_singletons[clust - 1] = np.append(
+                                branch_singletons[clust - 1], extender
+                            )
+                            branch_singletonHeights[clust - 1] = np.append(
+                                branch_singletonHeights[clust - 1], extender
+                            )
                         branch_singletons[clust - 1][ns - 1] = gene
-                        branch_singletonHeights[clust - 1][ns - 1] = dendro_height[merge]
+                        branch_singletonHeights[clust - 1][ns - 1] = dendro_height[
+                            merge
+                        ]
                     else:
                         onBranch[int(gene) - 1] = clust
 
                     if nm >= len(branch_mergingHeights[clust - 1]):
-                        branch_mergingHeights[clust - 1] = np.append(branch_mergingHeights[clust - 1], extender)
+                        branch_mergingHeights[clust - 1] = np.append(
+                            branch_mergingHeights[clust - 1], extender
+                        )
                     branch_mergingHeights[clust - 1][nm - 1] = dendro_height[merge]
                     branch_size[clust - 1] = branch_size[clust - 1] + 1
                     branch_nMerge[clust - 1] = nm
@@ -1455,45 +1782,65 @@ class WGCNA(GeneExp):
                     sizes = sizes[rnk - 1]
 
                     if branch_isBasic[small - 1]:
-                        coresize = WGCNA.coreSizeFunc(branch_nSingletons[small - 1], minClusterSize)
-                        Core = np.array(branch_singletons[small - 1][np.arange(coresize)] - 1, dtype=int)
+                        coresize = WGCNA.coreSizeFunc(
+                            branch_nSingletons[small - 1], minClusterSize
+                        )
+                        Core = np.array(
+                            branch_singletons[small - 1][np.arange(coresize)] - 1,
+                            dtype=int,
+                        )
                         SmAveDist = np.mean(distM.iloc[Core, Core].sum() / coresize - 1)
                     else:
                         SmAveDist = 0
 
                     if branch_isBasic[large - 1]:
-                        coresize = WGCNA.coreSizeFunc(branch_nSingletons[large - 1], minClusterSize)
-                        Core = np.array(branch_singletons[large - 1][np.arange(int(coresize))] - 1, dtype=int)
+                        coresize = WGCNA.coreSizeFunc(
+                            branch_nSingletons[large - 1], minClusterSize
+                        )
+                        Core = np.array(
+                            branch_singletons[large - 1][np.arange(int(coresize))] - 1,
+                            dtype=int,
+                        )
                         LgAveDist = np.mean(distM.iloc[Core, Core].sum() / coresize - 1)
                     else:
                         LgAveDist = 0
 
-                    mergeDiagnostics.loc[merge, :] = [small,
-                                                      branch_size[small - 1],
-                                                      SmAveDist,
-                                                      dendro_height[merge] - SmAveDist,
-                                                      large,
-                                                      branch_size[large - 1],
-                                                      LgAveDist,
-                                                      dendro_height[merge] - LgAveDist,
-                                                      None]
-                    SmallerScores = [branch_isBasic[small - 1],
-                                     branch_size[small - 1] < minClusterSize,
-                                     SmAveDist > maxAbsCoreScatter,
-                                     dendro_height[merge] - SmAveDist < minAbsGap,
-                                     dendro_height[merge] < minAbsSplitHeight]
+                    mergeDiagnostics.loc[merge, :] = [
+                        small,
+                        branch_size[small - 1],
+                        SmAveDist,
+                        dendro_height[merge] - SmAveDist,
+                        large,
+                        branch_size[large - 1],
+                        LgAveDist,
+                        dendro_height[merge] - LgAveDist,
+                        None,
+                    ]
+                    SmallerScores = [
+                        branch_isBasic[small - 1],
+                        branch_size[small - 1] < minClusterSize,
+                        SmAveDist > maxAbsCoreScatter,
+                        dendro_height[merge] - SmAveDist < minAbsGap,
+                        dendro_height[merge] < minAbsSplitHeight,
+                    ]
                     if SmallerScores[0] * np.count_nonzero(SmallerScores[1:]) > 0:
                         DoMerge = True
-                        SmallerFailSize = ~np.logical_or(SmallerScores[2], SmallerScores[3])
+                        SmallerFailSize = ~np.logical_or(
+                            SmallerScores[2], SmallerScores[3]
+                        )
                     else:
-                        LargerScores = [branch_isBasic[large - 1],
-                                        branch_size[large - 1] < minClusterSize,
-                                        LgAveDist > maxAbsCoreScatter,
-                                        dendro_height[merge] - LgAveDist < minAbsGap,
-                                        dendro_height[merge] < minAbsSplitHeight]
+                        LargerScores = [
+                            branch_isBasic[large - 1],
+                            branch_size[large - 1] < minClusterSize,
+                            LgAveDist > maxAbsCoreScatter,
+                            dendro_height[merge] - LgAveDist < minAbsGap,
+                            dendro_height[merge] < minAbsSplitHeight,
+                        ]
                         if LargerScores[0] * np.count_nonzero(LargerScores[1:]) > 0:
                             DoMerge = True
-                            SmallerFailSize = ~np.logical_or(LargerScores[2], LargerScores[3])
+                            SmallerFailSize = ~np.logical_or(
+                                LargerScores[2], LargerScores[3]
+                            )
                             x = small
                             small = large
                             large = x
@@ -1502,23 +1849,35 @@ class WGCNA(GeneExp):
                             DoMerge = False
 
                     if DoMerge:
-                        mergeDiagnostics['merged'][merge] = 1
+                        mergeDiagnostics["merged"][merge] = 1
 
-                    if not DoMerge and nExternalSplits > 0 and branch_isBasic[small - 1] and branch_isBasic[large - 1]:
+                    if (
+                        not DoMerge
+                        and nExternalSplits > 0
+                        and branch_isBasic[small - 1]
+                        and branch_isBasic[large - 1]
+                    ):
                         branch1 = branch_singletons[large - 1][np.arange(sizes[1])]
                         branch2 = branch_singletons[small - 1][np.arange(sizes[0])]
                         es = 0
                         while es < nExternalSplits and not DoMerge:
                             es = es + 1
-                            args = pd.DataFrame({'externalSplitOptions': externalSplitOptions[es - 1],
-                                                 'branch1': branch1, 'branch2': branch2})
+                            args = pd.DataFrame(
+                                {
+                                    "externalSplitOptions": externalSplitOptions[
+                                        es - 1
+                                    ],
+                                    "branch1": branch1,
+                                    "branch2": branch2,
+                                }
+                            )
                             # TODO: extSplit = do.call(externalBranchSplitFnc[[es]], args)
                             extSplit = None
                             DoMerge = extSplit < minExternalSplit[es - 1]
                             externalMergeDiags[merge, es - 1] = extSplit
-                            mergeDiagnostics['merged'][merge] = 0
+                            mergeDiagnostics["merged"][merge] = 0
                             if DoMerge:
-                                mergeDiagnostics['merged'][merge] = 2
+                                mergeDiagnostics["merged"][merge] = 2
 
                     if DoMerge:
                         branch_failSize[small - 1] = SmallerFailSize
@@ -1530,32 +1889,51 @@ class WGCNA(GeneExp):
                         ns = nss + nsl
 
                         if branch_isBasic[large - 1]:
-                            nExt = np.ceil((ns - len(branch_singletons[large - 1])) / chunkSize)
+                            nExt = np.ceil(
+                                (ns - len(branch_singletons[large - 1])) / chunkSize
+                            )
                             if nExt > 0:
-                                branch_singletons[large - 1] = np.append(branch_singletons[large - 1],
-                                                                         np.repeat(extender, nExt))
-                                branch_singletonHeights[large - 1] = np.append(branch_singletonHeights[large - 1],
-                                                                               np.repeat(extender, nExt))
+                                branch_singletons[large - 1] = np.append(
+                                    branch_singletons[large - 1],
+                                    np.repeat(extender, nExt),
+                                )
+                                branch_singletonHeights[large - 1] = np.append(
+                                    branch_singletonHeights[large - 1],
+                                    np.repeat(extender, nExt),
+                                )
 
-                            branch_singletons[large - 1][np.arange(nsl, ns)] = branch_singletons[small - 1][
-                                np.arange(nss)]
-                            branch_singletonHeights[large - 1][np.arange(nsl, ns)] = branch_singletonHeights[small - 1][
-                                np.arange(nss)]
+                            branch_singletons[large - 1][np.arange(nsl, ns)] = (
+                                branch_singletons[small - 1][np.arange(nss)]
+                            )
+                            branch_singletonHeights[large - 1][np.arange(nsl, ns)] = (
+                                branch_singletonHeights[small - 1][np.arange(nss)]
+                            )
                             branch_nSingletons[large] = ns
                         else:
                             if not branch_isBasic[small - 1]:
-                                sys.exit("Internal error: merging two composite clusters. Sorry!")
+                                sys.exit(
+                                    "Internal error: merging two composite clusters. Sorry!"
+                                )
 
-                            onBranch[branch_singletons[small - 1][branch_singletons[small - 1] != 0] - 1] = large
+                            onBranch[
+                                branch_singletons[small - 1][
+                                    branch_singletons[small - 1] != 0
+                                ]
+                                - 1
+                            ] = large
 
                         nm = branch_nMerge[large - 1] + 1
 
                         if nm > len(branch_mergingHeights[large - 1]):
-                            branch_mergingHeights[large - 1] = np.append(branch_mergingHeights[large - 1], extender)
+                            branch_mergingHeights[large - 1] = np.append(
+                                branch_mergingHeights[large - 1], extender
+                            )
 
                         branch_mergingHeights[large - 1][nm - 1] = dendro_height[merge]
                         branch_nMerge[large - 1] = nm
-                        branch_size[large - 1] = branch_size[small - 1] + branch_size[large - 1]
+                        branch_size[large - 1] = (
+                            branch_size[small - 1] + branch_size[large - 1]
+                        )
                         IndMergeToBranch[merge] = large
                         RootBranch = large
                     else:
@@ -1565,9 +1943,13 @@ class WGCNA(GeneExp):
                             small = x
                             sizes = np.flip(sizes)
 
-                        if branch_isBasic[large - 1] or (pamStage and pamRespectsDendro):
+                        if branch_isBasic[large - 1] or (
+                            pamStage and pamRespectsDendro
+                        ):
                             nBranches = nBranches + 1
-                            branch_attachHeight[[large - 1, small - 1]] = dendro_height[merge]
+                            branch_attachHeight[[large - 1, small - 1]] = dendro_height[
+                                merge
+                            ]
                             branch_mergedInto[[large - 1, small - 1]] = nBranches
                             if branch_isBasic[small - 1]:
                                 addBasicClusters = small
@@ -1576,37 +1958,59 @@ class WGCNA(GeneExp):
                             if branch_isBasic[large - 1]:
                                 addBasicClusters = np.append(addBasicClusters, large)
                             else:
-                                addBasicClusters = np.append(addBasicClusters, branch_basicClusters[large - 1])
+                                addBasicClusters = np.append(
+                                    addBasicClusters, branch_basicClusters[large - 1]
+                                )
                             branch_isBasic[nBranches - 1] = False
                             branch_isTopBasic[nBranches - 1] = False
                             branch_basicClusters[nBranches - 1] = addBasicClusters
-                            branch_mergingHeights[nBranches - 1] = np.append(np.repeat(dendro_height[merge], 2),
-                                                                             extender)
+                            branch_mergingHeights[nBranches - 1] = np.append(
+                                np.repeat(dendro_height[merge], 2), extender
+                            )
                             branch_nMerge[nBranches - 1] = 2
                             branch_size[nBranches - 1] = np.sum(sizes)
                             branch_nBasicClusters[nBranches - 1] = len(addBasicClusters)
                             IndMergeToBranch[merge] = nBranches
                             RootBranch = nBranches
                         else:
-                            addBasicClusters = [small] if branch_isBasic[small - 1] else branch_basicClusters[small - 1]
+                            addBasicClusters = (
+                                [small]
+                                if branch_isBasic[small - 1]
+                                else branch_basicClusters[small - 1]
+                            )
 
                             nbl = branch_nBasicClusters[large - 1]
-                            nb = branch_nBasicClusters[large - 1] + len(addBasicClusters)
+                            nb = branch_nBasicClusters[large - 1] + len(
+                                addBasicClusters
+                            )
 
                             if nb > len(branch_basicClusters[large - 1]):
-                                nExt = np.ceil((nb - len(branch_basicClusters[large - 1])) / chunkSize)
-                                branch_basicClusters[large - 1] = np.append(branch_basicClusters[large - 1],
-                                                                            np.repeat(extender, nExt))
+                                nExt = np.ceil(
+                                    (nb - len(branch_basicClusters[large - 1]))
+                                    / chunkSize
+                                )
+                                branch_basicClusters[large - 1] = np.append(
+                                    branch_basicClusters[large - 1],
+                                    np.repeat(extender, nExt),
+                                )
 
-                            branch_basicClusters[large - 1][np.arange(nbl, nb)] = addBasicClusters
+                            branch_basicClusters[large - 1][np.arange(nbl, nb)] = (
+                                addBasicClusters
+                            )
                             branch_nBasicClusters[large - 1] = nb
-                            branch_size[large - 1] = branch_size[large - 1] + branch_size[small - 1]
+                            branch_size[large - 1] = (
+                                branch_size[large - 1] + branch_size[small - 1]
+                            )
                             nm = branch_nMerge[large - 1] + 1
 
                             if nm > len(branch_mergingHeights[large - 1]):
-                                branch_mergingHeights[large - 1] = np.append(branch_mergingHeights[large - 1], extender)
+                                branch_mergingHeights[large - 1] = np.append(
+                                    branch_mergingHeights[large - 1], extender
+                                )
 
-                            branch_mergingHeights[large - 1][nm - 1] = dendro_height[merge]
+                            branch_mergingHeights[large - 1][nm - 1] = dendro_height[
+                                merge
+                            ]
                             branch_nMerge[large - 1] = nm
                             branch_attachHeight[small - 1] = dendro_height[merge]
                             branch_mergedInto[small - 1] = large
@@ -1621,11 +2025,16 @@ class WGCNA(GeneExp):
                 branch_attachHeight[clust] = cutHeight
             if branch_isTopBasic[clust]:
                 coresize = WGCNA.coreSizeFunc(branch_nSingletons[clust], minClusterSize)
-                Core = np.array(branch_singletons[clust][np.arange(coresize)] - 1, dtype=int)
+                Core = np.array(
+                    branch_singletons[clust][np.arange(coresize)] - 1, dtype=int
+                )
                 CoreScatter = np.mean(distM.iloc[Core, Core].sum() / (coresize - 1))
-                isCluster[clust] = (branch_isTopBasic[clust] and branch_size[clust] >= minClusterSize and
-                                    CoreScatter < maxAbsCoreScatter and branch_attachHeight[
-                                        clust] - CoreScatter > minAbsGap)
+                isCluster[clust] = (
+                    branch_isTopBasic[clust]
+                    and branch_size[clust] >= minClusterSize
+                    and CoreScatter < maxAbsCoreScatter
+                    and branch_attachHeight[clust] - CoreScatter > minAbsGap
+                )
             else:
                 CoreScatter = 0
             if branch_failSize[clust]:
@@ -1645,7 +2054,9 @@ class WGCNA(GeneExp):
             Colors[branch_singletons[clust][branch_singletons[clust] != 0] - 1] = color
             SmallLabels[branch_singletons[clust][branch_singletons[clust] != 0] - 1] = 0
             coresize = WGCNA.coreSizeFunc(branch_nSingletons[clust], minClusterSize)
-            Core = np.array(branch_singletons[clust][np.arange(coresize)] - 1, dtype=int)
+            Core = np.array(
+                branch_singletons[clust][np.arange(coresize)] - 1, dtype=int
+            )
             coreLabels[Core] = color
             branchLabels[clust] = color
 
@@ -1670,12 +2081,16 @@ class WGCNA(GeneExp):
                     DistInCluster = distM.iloc[InCluster - 1, InCluster - 1]
                     DistSums = DistInCluster.sum(axis=0)
                     Medoids[cluster - 1] = InCluster[DistSums.idxmin()]
-                    ClusterRadii[cluster - 1] = np.max(DistInCluster[:, DistSums.idxmin()])
+                    ClusterRadii[cluster - 1] = np.max(
+                        DistInCluster[:, DistSums.idxmin()]
+                    )
 
                 if respectSmallClusters:
                     FSmallLabels = pd.Categorical(SmallLabels)
                     SmallLabLevs = pd.to_numeric(FSmallLabels.categories)
-                    nSmallClusters = len(FSmallLabels.categories) - (SmallLabLevs[1] == 0)
+                    nSmallClusters = len(FSmallLabels.categories) - (
+                        SmallLabLevs[1] == 0
+                    )
 
                     if nSmallClusters > 0:
                         for sclust in SmallLabLevs[SmallLabLevs != 0]:
@@ -1683,8 +2098,10 @@ class WGCNA(GeneExp):
                             if pamRespectsDendro:
                                 onBr = np.unique(onBranch[InCluster])
                                 if len(onBr) > 1:
-                                    msg = "Internal error: objects in a small cluster are marked to belong\n " \
-                                          "to several large branches:" + str(onBr)
+                                    msg = (
+                                        "Internal error: objects in a small cluster are marked to belong\n "
+                                        "to several large branches:" + str(onBr)
+                                    )
                                     sys.exit(msg)
 
                                 if onBr > 0:
@@ -1701,11 +2118,16 @@ class WGCNA(GeneExp):
                                 if len(InCluster) > 1:
                                     DistSums = DistInCluster.sum(axis=1)
                                     smed = InCluster[DistSums.idxmin()]
-                                    DistToMeds = distM.iloc[Medoids[labelsOnBranch - 1] - 1, smed]
+                                    DistToMeds = distM.iloc[
+                                        Medoids[labelsOnBranch - 1] - 1, smed
+                                    ]
                                     closest = DistToMeds.idxmin()
                                     DistToClosest = DistToMeds[closest]
                                     closestLabel = labelsOnBranch[closest]
-                                    if DistToClosest < ClusterRadii[closestLabel - 1] or DistToClosest < maxPamDist:
+                                    if (
+                                        DistToClosest < ClusterRadii[closestLabel - 1]
+                                        or DistToClosest < maxPamDist
+                                    ):
                                         Colors[InCluster] = closestLabel
                                         nPAMed = nPAMed + len(InCluster)
                                 else:
@@ -1727,14 +2149,19 @@ class WGCNA(GeneExp):
                             labelsOnBranch = np.arange(nProperLabels)
 
                         if labelsOnBranch is not None:
-                            UnassdToMedoidDist = distM.iloc[Medoids[labelsOnBranch - 1] - 1, obj]
+                            UnassdToMedoidDist = distM.iloc[
+                                Medoids[labelsOnBranch - 1] - 1, obj
+                            ]
                             nearest = UnassdToMedoidDist.idxmin()
                             NearestCenterDist = UnassdToMedoidDist[nearest]
                             nearestMed = labelsOnBranch[nearest]
-                            if NearestCenterDist < ClusterRadii[nearestMed - 1] or NearestCenterDist < maxPamDist:
+                            if (
+                                NearestCenterDist < ClusterRadii[nearestMed - 1]
+                                or NearestCenterDist < maxPamDist
+                            ):
                                 Colors[obj] = nearestMed
                                 nPAMed = nPAMed + 1
-                    UnlabeledExist = (sum(Colors == 0) > 0)
+                    UnlabeledExist = sum(Colors == 0) > 0
             else:
                 ClusterDiam = np.zeros((nProperLabels,))
                 for cluster in range(nProperLabels):
@@ -1752,15 +2179,19 @@ class WGCNA(GeneExp):
                 if respectSmallClusters:
                     FSmallLabels = pd.Categorical(SmallLabels)
                     SmallLabLevs = pd.to_numeric(FSmallLabels.categories)
-                    nSmallClusters = len(FSmallLabels.categories) - (SmallLabLevs[0] == 0)
+                    nSmallClusters = len(FSmallLabels.categories) - (
+                        SmallLabLevs[0] == 0
+                    )
                     if nSmallClusters > 0:
                         if pamRespectsDendro:
                             for sclust in SmallLabLevs[SmallLabLevs != 0]:
                                 InCluster = np.where(SmallLabels == sclust)[0].tolist()
                                 onBr = pd.unique(onBranch[InCluster])
                                 if len(onBr) > 1:
-                                    msg = "Internal error: objects in a small cluster are marked to belong\n" \
-                                          "to several large branches:" + str(onBr)
+                                    msg = (
+                                        "Internal error: objects in a small cluster are marked to belong\n"
+                                        "to several large branches:" + str(onBr)
+                                    )
                                     sys.exit(msg)
                                 if onBr > 0:
                                     basicOnBranch = branch_basicClusters[onBr[0] - 1]
@@ -1768,14 +2199,27 @@ class WGCNA(GeneExp):
                                     useObjects = ColorsX in np.unique(labelsOnBranch)
                                     DistSClustClust = distM.iloc[InCluster, useObjects]
                                     MeanDist = DistSClustClust.mean(axis=0)
-                                    useColorsFac = ColorsX[useObjects]  # pd.Categorical(ColorsX[useObjects])
-                                    MeanDist = pd.DataFrame({'MeanDist': MeanDist, 'useColorsFac': useColorsFac})
+                                    useColorsFac = ColorsX[
+                                        useObjects
+                                    ]  # pd.Categorical(ColorsX[useObjects])
+                                    MeanDist = pd.DataFrame(
+                                        {
+                                            "MeanDist": MeanDist,
+                                            "useColorsFac": useColorsFac,
+                                        }
+                                    )
                                     MeanMeanDist = MeanDist.groupby(
-                                        'useColorsFac').mean()  # tapply(MeanDist, useColorsFac, mean)
-                                    nearest = MeanMeanDist[['MeanDist']].idxmin().astype(int) - 1
-                                    NearestDist = MeanMeanDist[['MeanDist']].min()
-                                    if np.logical_or(np.all(NearestDist < ClusterDiam[nearest]),
-                                                     NearestDist < maxPamDist).tolist()[0]:
+                                        "useColorsFac"
+                                    ).mean()  # tapply(MeanDist, useColorsFac, mean)
+                                    nearest = (
+                                        MeanMeanDist[["MeanDist"]].idxmin().astype(int)
+                                        - 1
+                                    )
+                                    NearestDist = MeanMeanDist[["MeanDist"]].min()
+                                    if np.logical_or(
+                                        np.all(NearestDist < ClusterDiam[nearest]),
+                                        NearestDist < maxPamDist,
+                                    ).tolist()[0]:
                                         Colors[InCluster] = nearest
                                         nPAMed = nPAMed + len(InCluster)
                                     else:
@@ -1787,14 +2231,23 @@ class WGCNA(GeneExp):
                                 InCluster = np.where(SmallLabels == sclust)[0].tolist()
                                 DistSClustClust = distM.iloc[InCluster, useObjects]
                                 MeanDist = DistSClustClust.mean(axis=0)
-                                useColorsFac = ColorsX[useObjects]  # pd.Categorical(ColorsX[useObjects])
-                                MeanDist = pd.DataFrame({'MeanDist': MeanDist, 'useColorsFac': useColorsFac})
+                                useColorsFac = ColorsX[
+                                    useObjects
+                                ]  # pd.Categorical(ColorsX[useObjects])
+                                MeanDist = pd.DataFrame(
+                                    {"MeanDist": MeanDist, "useColorsFac": useColorsFac}
+                                )
                                 MeanMeanDist = MeanDist.groupby(
-                                    'useColorsFac').mean()  # tapply(MeanDist, useColorsFac, mean)
-                                nearest = MeanMeanDist[['MeanDist']].idxmin().astype(int) - 1
-                                NearestDist = MeanMeanDist[['MeanDist']].min()
-                                if np.logical_or(np.all(NearestDist < ClusterDiam[nearest]),
-                                                 NearestDist < maxPamDist).tolist()[0]:
+                                    "useColorsFac"
+                                ).mean()  # tapply(MeanDist, useColorsFac, mean)
+                                nearest = (
+                                    MeanMeanDist[["MeanDist"]].idxmin().astype(int) - 1
+                                )
+                                NearestDist = MeanMeanDist[["MeanDist"]].min()
+                                if np.logical_or(
+                                    np.all(NearestDist < ClusterDiam[nearest]),
+                                    NearestDist < maxPamDist,
+                                ).tolist()[0]:
                                     Colors[InCluster] = nearest
                                     nPAMed = nPAMed + len(InCluster)
                                 else:
@@ -1809,52 +2262,82 @@ class WGCNA(GeneExp):
                                 basicOnBranch = branch_basicClusters[onBr - 1]
                                 labelsOnBranch = branchLabels[basicOnBranch - 1]
                                 useObjects = ColorsX in np.unique(labelsOnBranch)
-                                useColorsFac = ColorsX[useObjects]  # pd.Categorical(ColorsX[useObjects])
-                                UnassdToClustDist = distM.iloc[useObjects, obj].groupby(
-                                    'useColorsFac').mean()  # tapply(distM[useObjects, obj], useColorsFac, mean)
+                                useColorsFac = ColorsX[
+                                    useObjects
+                                ]  # pd.Categorical(ColorsX[useObjects])
+                                UnassdToClustDist = (
+                                    distM.iloc[useObjects, obj]
+                                    .groupby("useColorsFac")
+                                    .mean()
+                                )  # tapply(distM[useObjects, obj], useColorsFac, mean)
                                 nearest = UnassdToClustDist.idxmin().astype(int) - 1
                                 NearestClusterDist = UnassdToClustDist[nearest]
-                                nearestLabel = pd.to_numeric(useColorsFac.categories[nearest])
-                                if np.logical_or(np.all(NearestClusterDist < ClusterDiam[nearest]),
-                                                 NearestClusterDist < maxPamDist).tolist()[0]:
+                                nearestLabel = pd.to_numeric(
+                                    useColorsFac.categories[nearest]
+                                )
+                                if np.logical_or(
+                                    np.all(NearestClusterDist < ClusterDiam[nearest]),
+                                    NearestClusterDist < maxPamDist,
+                                ).tolist()[0]:
                                     Colors[obj] = nearest
                                     nPAMed = nPAMed + 1
                             else:
                                 labelsOnBranch = None
                     else:
                         useObjects = np.where(ColorsX != 0)[0].tolist()
-                        useColorsFac = ColorsX[useObjects]  # pd.Categorical(ColorsX[useObjects])
+                        useColorsFac = ColorsX[
+                            useObjects
+                        ]  # pd.Categorical(ColorsX[useObjects])
                         tmp = pd.DataFrame(distM.iloc[useObjects, Unlabeled])
-                        tmp['group'] = useColorsFac
+                        tmp["group"] = useColorsFac
                         UnassdToClustDist = tmp.groupby(
-                            ['group']).mean()  # apply(distM[useObjects, Unlabeled], 2, tapply, useColorsFac, mean)
-                        nearest = np.subtract(UnassdToClustDist.idxmin(axis=0),
-                                              np.ones(UnassdToClustDist.shape[1])).astype(
-                            int)  # apply(UnassdToClustDist, 2, which.min)
-                        nearestDist = UnassdToClustDist.min(axis=0)  # apply(UnassdToClustDist, 2, min)
+                            ["group"]
+                        ).mean()  # apply(distM[useObjects, Unlabeled], 2, tapply, useColorsFac, mean)
+                        nearest = np.subtract(
+                            UnassdToClustDist.idxmin(axis=0),
+                            np.ones(UnassdToClustDist.shape[1]),
+                        ).astype(int)  # apply(UnassdToClustDist, 2, which.min)
+                        nearestDist = UnassdToClustDist.min(
+                            axis=0
+                        )  # apply(UnassdToClustDist, 2, min)
                         nearestLabel = nearest + 1
-                        sumAssign = np.sum(np.logical_or(nearestDist < ClusterDiam[nearest], nearestDist < maxPamDist))
-                        assign = np.where(np.logical_or(nearestDist < ClusterDiam[nearest], nearestDist < maxPamDist))[
-                            0].tolist()
+                        sumAssign = np.sum(
+                            np.logical_or(
+                                nearestDist < ClusterDiam[nearest],
+                                nearestDist < maxPamDist,
+                            )
+                        )
+                        assign = np.where(
+                            np.logical_or(
+                                nearestDist < ClusterDiam[nearest],
+                                nearestDist < maxPamDist,
+                            )
+                        )[0].tolist()
                         tmp = [Unlabeled[x] for x in assign]
                         Colors[tmp] = [nearestLabel.iloc[x] for x in assign]
                         nPAMed = nPAMed + sumAssign
 
         Colors[np.where(Colors < 0)[0].tolist()] = 0
-        UnlabeledExist = (np.count_nonzero(Colors == 0) > 0)
+        UnlabeledExist = np.count_nonzero(Colors == 0) > 0
         NumLabs = list(map(int, Colors.copy()))
         Sizes = pd.DataFrame(NumLabs).value_counts().sort_index()
-        OrdNumLabs = pd.DataFrame({"Name": NumLabs, "Value": np.repeat(1, len(NumLabs))})
+        OrdNumLabs = pd.DataFrame(
+            {"Name": NumLabs, "Value": np.repeat(1, len(NumLabs))}
+        )
 
         if UnlabeledExist:
             if len(Sizes) > 1:
-                SizeRank = np.insert(stats.rankdata(-1 * Sizes[1:len(Sizes)], method='ordinal') + 1, 0, 1)
+                SizeRank = np.insert(
+                    stats.rankdata(-1 * Sizes[1 : len(Sizes)], method="ordinal") + 1,
+                    0,
+                    1,
+                )
             else:
                 SizeRank = [1]
             for i in range(len(NumLabs)):
                 OrdNumLabs.Value[i] = SizeRank[NumLabs[i] - 1]
         else:
-            SizeRank = stats.rankdata(-1 * Sizes, method='ordinal')
+            SizeRank = stats.rankdata(-1 * Sizes, method="ordinal")
             for i in range(len(NumLabs)):
                 OrdNumLabs.Value[i] = SizeRank[NumLabs[i] - 1]
 
@@ -1882,12 +2365,15 @@ class WGCNA(GeneExp):
         """
         if colorSeq is None:
             colors = mcolors.CSS4_COLORS
-            colors = pd.DataFrame({"name": list(colors.keys()),
-                                   "color": list(colors.values())})
-            colors.drop_duplicates(subset='color', keep="last", inplace=True)
+            colors = pd.DataFrame(
+                {"name": list(colors.keys()), "color": list(colors.values())}
+            )
+            colors.drop_duplicates(subset="color", keep="last", inplace=True)
             # Sort colors by hue, saturation, value and name.
-            by_hsv = sorted((tuple(mcolors.rgb_to_hsv(mcolors.to_rgba(color)[:3])), name)
-                            for name, color in colors.itertuples(index=False))
+            by_hsv = sorted(
+                (tuple(mcolors.rgb_to_hsv(mcolors.to_rgba(color)[:3])), name)
+                for name, color in colors.itertuples(index=False)
+            )
             colorSeq = [name for hsv, name in by_hsv]
             colorSeq.remove(naColor)
 
@@ -1905,8 +2391,10 @@ class WGCNA(GeneExp):
 
         if np.max(nLabels.Value) > len(colorSeq):
             nRepeats = int((np.max(labels.Value) - 1) / len(colorSeq)) + 1
-            print(f"{WARNING}labels2colors: Number of labels exceeds number of avilable colors.\n"
-                  f"Some colors will be repeated {str(nRepeats)} times.{ENDC}")
+            print(
+                f"{WARNING}labels2colors: Number of labels exceeds number of avilable colors.\n"
+                f"Some colors will be repeated {str(nRepeats)} times.{ENDC}"
+            )
             extColorSeq = colorSeq
             for rep in range(nRepeats):
                 tmp = [str(item) + "." + str(rep) for item in colorSeq]
@@ -1924,8 +2412,19 @@ class WGCNA(GeneExp):
         return colors
 
     @staticmethod
-    def moduleEigengenes(expr, colors, impute=True, nPC=1, align="along average", excludeGrey=False, grey="grey",
-                         subHubs=True, softPower=6, scaleVar=True, trapErrors=False):
+    def moduleEigengenes(
+        expr,
+        colors,
+        impute=True,
+        nPC=1,
+        align="along average",
+        excludeGrey=False,
+        grey="grey",
+        subHubs=True,
+        softPower=6,
+        scaleVar=True,
+        trapErrors=False,
+    ):
         """
         Calculates module eigengenes (1st principal component) of modules in a given single dataset.
 
@@ -1955,7 +2454,9 @@ class WGCNA(GeneExp):
         :return: A dictionary containing: "eigengenes": Module eigengenes in a dataframe, with each column corresponding to one eigengene. The columns are named by the corresponding color with an "ME" prepended, e.g., MEturquoise etc. If returnValidOnly==FALSE, module eigengenes whose calculation failed have all components set to NA. "averageExpr": If align == "along average", a dataframe containing average normalized expression in each module. The columns are named by the corresponding color with an "AE" prepended, e.g., AEturquoise etc. "varExplained": A dataframe in which each column corresponds to a module, with the component varExplained[PC, module] giving the variance of module module explained by the principal component no. PC. The calculation is exact irrespective of the number of computed principal components. At most 10 variance explained values are recorded in this dataframe. "nPC": A copy of the input nPC. "validMEs": A boolean vector. Each component (corresponding to the columns in data) is TRUE if the corresponding eigengene is valid, and FALSE if it is invalid. Valid eigengenes include both principal components and their hubgene approximations. When returnValidOnly==FALSE, by definition all returned eigengenes are valid and the entries of validMEs are all TRUE. "validColors": A copy of the input colors with entries corresponding to invalid modules set to grey if given, otherwise 0 if colors is numeric and "grey" otherwise. "allOK": Boolean flag signalling whether all eigengenes have been calculated correctly, either as principal components or as the hubgene average approximation. "allPC": Boolean flag signalling whether all returned eigengenes are principal components. "isPC": Boolean vector. Each component (corresponding to the columns in eigengenes) is TRUE if the corresponding eigengene is the first principal component and FALSE if it is the hubgene approximation or is invalid. "isHub": Boolean vector. Each component (corresponding to the columns in eigengenes) is TRUE if the corresponding eigengene is the hubgene approximation and FALSE if it is the first principal component or is invalid. "validAEs": Boolean vector. Each component (corresponding to the columns in eigengenes) is TRUE if the corresponding module average expression is valid. "allAEOK": Boolean flag signalling whether all returned module average expressions contain valid data. Note that returnValidOnly==TRUE does not imply allAEOK==TRUE: some invalid average expressions may be returned if their corresponding eigengenes have been calculated correctly.
         :rtype: dict
         """
-        print(f"{OKCYAN}Calculating {len(pd.Categorical(colors).categories)} module eigengenes in given set...{ENDC}")
+        print(
+            f"{OKCYAN}Calculating {len(pd.Categorical(colors).categories)} module eigengenes in given set...{ENDC}"
+        )
         check = True
         pc = None
         returnValidOnly = trapErrors
@@ -1966,28 +2467,35 @@ class WGCNA(GeneExp):
         if colors is None:
             sys.exit("moduleEigengenes: Error: colors is NULL.")
         if isinstance(expr, dict):
-            expr = expr['data']
+            expr = expr["data"]
         if expr.shape is None or len(expr.shape) != 2:
             sys.exit("moduleEigengenes: Error: expr must be two-dimensional.")
         if expr.shape[1] != len(colors):
-            sys.exit("moduleEigengenes: Error: ncol(expr) and length(colors) must be equal (one color per gene).")
+            sys.exit(
+                "moduleEigengenes: Error: ncol(expr) and length(colors) must be equal (one color per gene)."
+            )
         if len(pd.Categorical(colors).categories) == 1:
             sys.exit(
-                f"{WARNING}All your genes ended up in one modules! Reconsider your input parameters in order to get more modules.{ENDC}")
+                f"{WARNING}All your genes ended up in one modules! Reconsider your input parameters in order to get more modules.{ENDC}"
+            )
         # TODO: "Argument 'colors' contains unused levels (empty modules). Use colors[, drop=TRUE] to get rid of them."
         if softPower < 0:
             sys.exit("softPower must be non-negative")
         maxVarExplained = 10
         if nPC > maxVarExplained:
-            print(f"{WARNING}Given nPC is too large. Will use value {str(maxVarExplained)}{ENDC}")
+            print(
+                f"{WARNING}Given nPC is too large. Will use value {str(maxVarExplained)}{ENDC}"
+            )
         nVarExplained = min(nPC, maxVarExplained)
         modlevels = pd.Categorical(colors).categories
         if excludeGrey:
             if len(np.where(modlevels != grey)) > 0:
                 modlevels = modlevels[np.where(modlevels != grey)]
             else:
-                sys.exit("Color levels are empty. Possible reason: the only color is grey and grey module is excluded "
-                         "from the calculation.")
+                sys.exit(
+                    "Color levels are empty. Possible reason: the only color is grey and grey module is excluded "
+                    "from the calculation."
+                )
         PrinComps = np.empty((expr.shape[0], len(modlevels)))
         PrinComps[:] = np.nan
         PrinComps = pd.DataFrame(PrinComps)
@@ -2009,7 +2517,7 @@ class WGCNA(GeneExp):
             averExpr.index = expr.index
         for i in range(len(modlevels)):
             modulename = modlevels[i]
-            restrict1 = (colors == modulename)
+            restrict1 = colors == modulename
             datModule = expr.loc[:, restrict1].T
             n = datModule.shape[0]
             p = datModule.shape[1]
@@ -2018,39 +2526,63 @@ class WGCNA(GeneExp):
                     seedSaved = True
                     if datModule.isnull().values.any():
                         # define imputer
-                        imputer = KNNImputer(n_neighbors=np.min(10, datModule.shape[0] - 1))
+                        imputer = KNNImputer(
+                            n_neighbors=np.min(10, datModule.shape[0] - 1)
+                        )
                         # fit on the dataset
                         imputer.fit(datModule)
                         # transform the dataset
                         datModule = imputer.transform(
-                            datModule)  # datModule = impute.knn(datModule, k = min(10, nrow(datModule) - 1))
+                            datModule
+                        )  # datModule = impute.knn(datModule, k = min(10, nrow(datModule) - 1))
                 if scaleVar:
-                    datModule = pd.DataFrame(scale(datModule.T).T, index=datModule.index, columns=datModule.columns)
+                    datModule = pd.DataFrame(
+                        scale(datModule.T).T,
+                        index=datModule.index,
+                        columns=datModule.columns,
+                    )
                 u, d, v = np.linalg.svd(datModule)
-                u = u[:, 0:min(n, p, nPC)]
-                v = v[0:min(n, p, nPC), :]
+                u = u[:, 0 : min(n, p, nPC)]
+                v = v[0 : min(n, p, nPC), :]
                 tmp = datModule.copy()
-                tmp = pd.concat([tmp, pd.DataFrame(v[0:min(n, p, nVarExplained), :],
-                                                   columns=tmp.columns.tolist())],
-                                ignore_index=True)
+                tmp = pd.concat(
+                    [
+                        tmp,
+                        pd.DataFrame(
+                            v[0 : min(n, p, nVarExplained), :],
+                            columns=tmp.columns.tolist(),
+                        ),
+                    ],
+                    ignore_index=True,
+                )
                 veMat = pd.DataFrame(np.corrcoef(tmp.values)).iloc[:-1, -1].T
-                varExpl.iloc[0:min(n, p, nVarExplained), i] = (veMat ** 2).mean(axis=0)
+                varExpl.iloc[0 : min(n, p, nVarExplained), i] = (veMat**2).mean(axis=0)
                 pc = v[0].tolist()
             except:
                 if not subHubs:
                     sys.exit("Error!")
                 if subHubs:
-                    print(" ..principal component calculation for module", modulename,
-                          "failed with the following error:", flush=True)
-                    print("     ..hub genes will be used instead of principal components.", flush=True)
+                    print(
+                        " ..principal component calculation for module",
+                        modulename,
+                        "failed with the following error:",
+                        flush=True,
+                    )
+                    print(
+                        "     ..hub genes will be used instead of principal components.",
+                        flush=True,
+                    )
 
                     isPC[i] = False
                     check = True
                     try:
-                        scaledExpr = pd.DataFrame(scale(datModule.T).T, index=datModule.index,
-                                                  columns=datModule.columns)
+                        scaledExpr = pd.DataFrame(
+                            scale(datModule.T).T,
+                            index=datModule.index,
+                            columns=datModule.columns,
+                        )
                         covEx = np.cov(scaledExpr)
-                        covEx[~ np.isfinite(covEx)] = 0
+                        covEx[~np.isfinite(covEx)] = 0
                         modAdj = np.abs(covEx) ** softPower
                         kIM = (modAdj.mean(axis=0)) ** 3
                         if np.max(kIM) > 1:
@@ -2064,18 +2596,28 @@ class WGCNA(GeneExp):
                         tmp.shape = scaledExpr.shape
                         pcxMat = scaledExpr * tmp / sum(kIM)
                         pcx = pcxMat.mean(axis=0)
-                        varExpl[0, i] = np.mean(np.corrcoef(pcx, datModule.transpose()) ** 2)
+                        varExpl[0, i] = np.mean(
+                            np.corrcoef(pcx, datModule.transpose()) ** 2
+                        )
                         pc = pcx
                     except:
                         check = False
             if not check:
                 if not trapErrors:
                     sys.exit("Error!")
-                print(" ..ME calculation of module", modulename, "failed with the following error:", flush=True)
-                print("     ", pc, " ..the offending module has been removed.", flush=True)
+                print(
+                    " ..ME calculation of module",
+                    modulename,
+                    "failed with the following error:",
+                    flush=True,
+                )
+                print(
+                    "     ", pc, " ..the offending module has been removed.", flush=True
+                )
                 print(
                     f"{WARNING}Eigengene calculation of module {modulename} failed with the following error \n"
-                    f"{pc} The offending module has been removed.{ENDC}")
+                    f"{pc} The offending module has been removed.{ENDC}"
+                )
                 validMEs[i] = False
                 isPC[i] = False
                 isHub[i] = False
@@ -2087,7 +2629,9 @@ class WGCNA(GeneExp):
                         scaledExpr = scale(datModule.T)
                     averExpr.iloc[:, i] = scaledExpr.mean(axis=1)
                     if align == "along average":
-                        corAve = np.corrcoef(averExpr.iloc[:, i], PrinComps.iloc[:, i])[0, 1]
+                        corAve = np.corrcoef(averExpr.iloc[:, i], PrinComps.iloc[:, i])[
+                            0, 1
+                        ]
                         if not np.isfinite(corAve):
                             corAve = 0
                         if corAve < 0:
@@ -2096,15 +2640,24 @@ class WGCNA(GeneExp):
                 except:
                     if not trapErrors:
                         sys.exit("Error!")
-                    print(" ..Average expression calculation of module", modulename,
-                          "failed with the following error:", flush=True)
-                    print(" ..the returned average expression vector will be invalid.", flush=True)
+                    print(
+                        " ..Average expression calculation of module",
+                        modulename,
+                        "failed with the following error:",
+                        flush=True,
+                    )
+                    print(
+                        " ..the returned average expression vector will be invalid.",
+                        flush=True,
+                    )
 
-                    print(f"{WARNING}Average expression calculation of module {modulename} "
-                          f"failed with the following error.\nThe returned average expression vector will "
-                          f"be invalid.\n{ENDC}")
+                    print(
+                        f"{WARNING}Average expression calculation of module {modulename} "
+                        f"failed with the following error.\nThe returned average expression vector will "
+                        f"be invalid.\n{ENDC}"
+                    )
 
-        allOK = (sum(np.logical_not(validMEs)) == 0)
+        allOK = sum(np.logical_not(validMEs)) == 0
         if returnValidOnly and sum(np.logical_not(validMEs)) > 0:
             PrinComps = PrinComps[:, validMEs]
             averExpr = averExpr[:, validMEs]
@@ -2114,14 +2667,25 @@ class WGCNA(GeneExp):
             isHub = isHub[validMEs]
             validAEs = validAEs[validMEs]
 
-        allPC = (sum(np.logical_not(isPC)) == 0)
-        allAEOK = (sum(np.logical_not(validAEs)) == 0)
+        allPC = sum(np.logical_not(isPC)) == 0
+        allAEOK = sum(np.logical_not(validAEs)) == 0
 
         print("\tDone..\n")
 
-        return {"eigengenes": PrinComps, "averageExpr": averExpr, "varExplained": varExpl, "nPC": nPC,
-                "validMEs": validMEs, "validColors": validColors, "allOK": allOK, "allPC": allPC, "isPC": isPC,
-                "isHub": isHub, "validAEs": validAEs, "allAEOK": allAEOK}
+        return {
+            "eigengenes": PrinComps,
+            "averageExpr": averExpr,
+            "varExplained": varExpl,
+            "nPC": nPC,
+            "validMEs": validMEs,
+            "validColors": validColors,
+            "allOK": allOK,
+            "allPC": allPC,
+            "isPC": isPC,
+            "isHub": isHub,
+            "validAEs": validAEs,
+            "allAEOK": allAEOK,
+        }
 
     @staticmethod
     def permissiveDim(x):
@@ -2160,18 +2724,22 @@ class WGCNA(GeneExp):
                 nGenes = 0
                 nSamples = 0
             else:
-                sys.exit("data does not appear to have the correct format. "
-                         "Consider using fixDataStructure or setting checkStructure = TRUE when calling this function.")
+                sys.exit(
+                    "data does not appear to have the correct format. "
+                    "Consider using fixDataStructure or setting checkStructure = TRUE when calling this function."
+                )
         elif isinstance(data, dict):
             nSamples = np.zeros(nSets)
-            nGenes = WGCNA.permissiveDim(data[useSets[0]]['data'])[1]
+            nGenes = WGCNA.permissiveDim(data[useSets[0]]["data"])[1]
             for set in useSets:
-                if nGenes != WGCNA.permissiveDim(data[set]['data'])[1]:
+                if nGenes != WGCNA.permissiveDim(data[set]["data"])[1]:
                     if checkStructure:
                         structureOK = False
                     else:
-                        sys.exit(("Incompatible number of genes in set 1 and", str(set)))
-                nSamples[set] = WGCNA.permissiveDim(data[set]['data'])[0]
+                        sys.exit(
+                            ("Incompatible number of genes in set 1 and", str(set))
+                        )
+                nSamples[set] = WGCNA.permissiveDim(data[set]["data"])[0]
         else:
             nSamples = np.zeros(nSets)
             nGenes = WGCNA.permissiveDim(data[useSets[0]])[1]
@@ -2180,9 +2748,16 @@ class WGCNA(GeneExp):
                     if checkStructure:
                         structureOK = False
                     else:
-                        sys.exit(("Incompatible number of genes in set 1 and", str(set)))
+                        sys.exit(
+                            ("Incompatible number of genes in set 1 and", str(set))
+                        )
                 nSamples[set] = WGCNA.permissiveDim(data[set])[0]
-        return {"nSets": nSets, "nGenes": nGenes, "nSamples": nSamples, "structureOK": structureOK}
+        return {
+            "nSets": nSets,
+            "nGenes": nGenes,
+            "nSamples": nSamples,
+            "structureOK": structureOK,
+        }
 
     @staticmethod
     def fixDataStructure(data):
@@ -2198,13 +2773,25 @@ class WGCNA(GeneExp):
         if not isinstance(data, list):
             print("fixDataStructure: data is not a Dictionary: converting it into one.")
             x = data.copy()
-            data = {0: {'data': x}}
+            data = {0: {"data": x}}
         return data
 
     @staticmethod
-    def multiSetMEs(exprData, colors, universalColors=None, useSets=None, useGenes=None, impute=True, nPC=1,
-                    align="along average", excludeGrey=False, subHubs=True, trapErrors=False, softPower=6,
-                    grey=None):
+    def multiSetMEs(
+        exprData,
+        colors,
+        universalColors=None,
+        useSets=None,
+        useGenes=None,
+        impute=True,
+        nPC=1,
+        align="along average",
+        excludeGrey=False,
+        subHubs=True,
+        trapErrors=False,
+        softPower=6,
+        grey=None,
+    ):
         """
         Calculates module eigengenes for several sets.
 
@@ -2251,8 +2838,8 @@ class WGCNA(GeneExp):
                 grey = "grey"
         nSets = len(exprData)
         setsize = WGCNA.checkSets(exprData, useSets=useSets)
-        nGenes = setsize['nGenes']
-        nSamples = setsize['nSamples']
+        nGenes = setsize["nGenes"]
+        nSamples = setsize["nSamples"]
         print("multiSetMEs: Calculating module MEs.", flush=True)
         MEs = {}
         consValidMEs = None
@@ -2267,17 +2854,27 @@ class WGCNA(GeneExp):
                     setColors = colors[:, set]
                 else:
                     setColors = universalColors
-                setMEs = WGCNA.moduleEigengenes(expr=exprData[set], colors=setColors, impute=impute, nPC=nPC,
-                                                align=align, excludeGrey=excludeGrey, grey=grey, trapErrors=trapErrors,
-                                                subHubs=subHubs, softPower=softPower)
-                if universalColors is not None and not setMEs['allOK']:
+                setMEs = WGCNA.moduleEigengenes(
+                    expr=exprData[set],
+                    colors=setColors,
+                    impute=impute,
+                    nPC=nPC,
+                    align=align,
+                    excludeGrey=excludeGrey,
+                    grey=grey,
+                    trapErrors=trapErrors,
+                    subHubs=subHubs,
+                    softPower=softPower,
+                )
+                if universalColors is not None and not setMEs["allOK"]:
                     if consValidMEs is None:
-                        consValidMEs = setMEs['validMEs']
+                        consValidMEs = setMEs["validMEs"]
                     else:
-                        consValidMEs = consValidMEs * setMEs['validMEs']
-                    consValidColors[setMEs['validColors'] != universalColors] = setMEs['validColors'][
-                        setMEs['validColors'] != universalColors]
-                setMEs['data'] = setMEs.pop("eigengenes")
+                        consValidMEs = consValidMEs * setMEs["validMEs"]
+                    consValidColors[setMEs["validColors"] != universalColors] = setMEs[
+                        "validColors"
+                    ][setMEs["validColors"] != universalColors]
+                setMEs["data"] = setMEs.pop("eigengenes")
                 MEs[set] = setMEs
         else:
             for set in useSets:
@@ -2286,73 +2883,95 @@ class WGCNA(GeneExp):
                     setColors = colors[useGenes, set]
                 else:
                     setColors = universalColors[useGenes]
-                setMEs = WGCNA.moduleEigengenes(expr=exprData[[set]][:, useGenes], colors=setColors, impute=impute,
-                                                nPC=nPC, align=align, excludeGrey=excludeGrey, grey=grey,
-                                                trapErrors=trapErrors, subHubs=subHubs, softPower=softPower)
-                if universalColors is not None and not setMEs['allOK']:
+                setMEs = WGCNA.moduleEigengenes(
+                    expr=exprData[[set]][:, useGenes],
+                    colors=setColors,
+                    impute=impute,
+                    nPC=nPC,
+                    align=align,
+                    excludeGrey=excludeGrey,
+                    grey=grey,
+                    trapErrors=trapErrors,
+                    subHubs=subHubs,
+                    softPower=softPower,
+                )
+                if universalColors is not None and not setMEs["allOK"]:
                     if consValidMEs is None:
-                        consValidMEs = setMEs['validMEs']
+                        consValidMEs = setMEs["validMEs"]
                     else:
-                        consValidMEs = consValidMEs * setMEs['validMEs']
-                    consValidColors[setMEs['validColors'] != universalColors[useGenes]] = \
-                        setMEs['validColors'][setMEs['validColors'] != universalColors[useGenes]]
-                setMEs['data'] = setMEs.pop("eigengenes")
+                        consValidMEs = consValidMEs * setMEs["validMEs"]
+                    consValidColors[
+                        setMEs["validColors"] != universalColors[useGenes]
+                    ] = setMEs["validColors"][
+                        setMEs["validColors"] != universalColors[useGenes]
+                    ]
+                setMEs["data"] = setMEs.pop("eigengenes")
                 MEs[set] = setMEs
         if universalColors is not None:
             for set in range(nSets):
                 if consValidMEs is not None:
-                    MEs[set]['validMEs'] = consValidMEs
-                MEs[set]['validColors'] = consValidColors
+                    MEs[set]["validMEs"] = consValidMEs
+                MEs[set]["validColors"] = consValidColors
         for set in range(nSets):
-            MEs[set]['allOK'] = (sum(np.logical_not(MEs[set]['validMEs'])) == 0)
+            MEs[set]["allOK"] = sum(np.logical_not(MEs[set]["validMEs"])) == 0
             if returnValidOnly:
-                valid = (MEs[set]['validMEs'] > 0)
-                MEs[set]['data'] = MEs[set]['data'][:, valid]
-                MEs[set]['averageExpr'] = MEs[set]['averageExpr'][:, valid]
-                MEs[set]['varExplained'] = MEs[set]['varExplained'][:, valid]
-                MEs[set]['isPC'] = MEs[set]['isPC'][valid]
-                MEs[set]['allPC'] = (sum(np.logical_not(MEs[set]['isPC'])) == 0)
-                MEs[set]['isHub'] = MEs[set]['isHub'][valid]
-                MEs[set]['validAEs'] = MEs[set]['validAEs'][valid]
-                MEs[set]['allAEOK'] = (sum(np.logical_not(MEs[set]['validAEs'])) == 0)
-                MEs[set]['validMEs'] = np.repeat(True, MEs[set]['data'].shape[1])
+                valid = MEs[set]["validMEs"] > 0
+                MEs[set]["data"] = MEs[set]["data"][:, valid]
+                MEs[set]["averageExpr"] = MEs[set]["averageExpr"][:, valid]
+                MEs[set]["varExplained"] = MEs[set]["varExplained"][:, valid]
+                MEs[set]["isPC"] = MEs[set]["isPC"][valid]
+                MEs[set]["allPC"] = sum(np.logical_not(MEs[set]["isPC"])) == 0
+                MEs[set]["isHub"] = MEs[set]["isHub"][valid]
+                MEs[set]["validAEs"] = MEs[set]["validAEs"][valid]
+                MEs[set]["allAEOK"] = sum(np.logical_not(MEs[set]["validAEs"])) == 0
+                MEs[set]["validMEs"] = np.repeat(True, MEs[set]["data"].shape[1])
         # names(MEs) = names(exprData)
         return MEs
 
     @staticmethod
-    def consensusMEDissimilarityMajor(MEs, useAbs=False, useSets=None, method="consensus"):
+    def consensusMEDissimilarityMajor(
+        MEs, useAbs=False, useSets=None, method="consensus"
+    ):
         """
         Calculates consensus dissimilarity (1-cor) of given module eigengenes realized in several sets.
         """
         methods = ["consensus", "majority"]
         m = methods.index(method)
         if m is None:
-            sys.exit(f"Unrecognized method given. Recognized values are {', '.join(methods)}")
+            sys.exit(
+                f"Unrecognized method given. Recognized values are {', '.join(methods)}"
+            )
         nSets = len(MEs)
         MEDiss = {}
         if useSets is None:
             useSets = list(range(nSets))
         for set in useSets:
             if useAbs:
-                diss = 1 - np.abs(np.corrcoef(MEs[set]['data'], rowvar=False))
+                diss = 1 - np.abs(np.corrcoef(MEs[set]["data"], rowvar=False))
             else:
-                diss = 1 - np.corrcoef(MEs[set]['data'], rowvar=False)
-            diss = pd.DataFrame(diss, index=MEs[set]['data'].columns, columns=MEs[set]['data'].columns)
+                diss = 1 - np.corrcoef(MEs[set]["data"], rowvar=False)
+            diss = pd.DataFrame(
+                diss, index=MEs[set]["data"].columns, columns=MEs[set]["data"].columns
+            )
             MEDiss[set] = {}
-            MEDiss[set]['Diss'] = diss
+            MEDiss[set]["Diss"] = diss
         for set in useSets:
             if set == useSets[0]:
-                ConsDiss = MEDiss[set]['Diss']
+                ConsDiss = MEDiss[set]["Diss"]
             else:
                 if m == 0:
-                    ConsDiss = pd.concat([ConsDiss, MEDiss[set]['Diss']]).max(
-                        level=0)  # pmax(ConsDiss, MEDiss[[set]]['Diss'])
+                    ConsDiss = pd.concat([ConsDiss, MEDiss[set]["Diss"]]).max(
+                        level=0
+                    )  # pmax(ConsDiss, MEDiss[[set]]['Diss'])
                 else:
-                    ConsDiss = ConsDiss + MEDiss[set]['Diss']
+                    ConsDiss = ConsDiss + MEDiss[set]["Diss"]
         if m == 1:
             ConsDiss = ConsDiss / nSets
-        ConsDiss = pd.DataFrame(ConsDiss, index=np.unique(MEs[useSets[0]]['data'].columns),
-                                columns=MEs[useSets[0]]['data'].columns)
+        ConsDiss = pd.DataFrame(
+            ConsDiss,
+            index=np.unique(MEs[useSets[0]]["data"].columns),
+            columns=MEs[useSets[0]]["data"].columns,
+        )
 
         return ConsDiss
 
@@ -2368,8 +2987,10 @@ class WGCNA(GeneExp):
         if greyLast and greyInd is not None:
             clusterMEs = np.where(greyName != distNames)[0].tolist()
             if len(clusterMEs) > 1:
-                h = WGCNA.hclust(pdist(distM.iloc[clusterMEs, clusterMEs]), method="average")
-                order = dendrogram(h, no_plot=True)['leaves']  # order
+                h = WGCNA.hclust(
+                    pdist(distM.iloc[clusterMEs, clusterMEs]), method="average"
+                )
+                order = dendrogram(h, no_plot=True)["leaves"]  # order
                 if len(np.where(np.array(order) >= greyInd)[0].tolist()) > 0:
                     for x in np.where(np.array(order) >= greyInd)[0].tolist():
                         order[x] = order[x] + 1
@@ -2384,13 +3005,15 @@ class WGCNA(GeneExp):
         else:
             if len(distM) > 1:
                 h = WGCNA.hclust(pdist(distM), method="average")
-                order = dendrogram(h, no_plot=True)['leaves']  # order
+                order = dendrogram(h, no_plot=True)["leaves"]  # order
             else:
                 order = 1
         return order
 
     @staticmethod
-    def orderMEs(MEs, greyLast=True, greyName="MEgrey", orderBy=0, order=None, useSets=None):
+    def orderMEs(
+        MEs, greyLast=True, greyName="MEgrey", orderBy=0, order=None, useSets=None
+    ):
         """
         Reorder given (eigen-)vectors such that similar ones (as measured by correlation) are next to each other.
 
@@ -2412,26 +3035,34 @@ class WGCNA(GeneExp):
         """
         if "eigengenes" in MEs.keys():
             if order is None:
-                print("orderMEs: order not given, calculating using given set", str(orderBy), flush=True)
-                disPC = 1 - np.corrcoef(MEs['eigengenes'], rowvar=False)
-                disPC = pd.DataFrame(disPC, index=MEs['eigengenes'].index, columns=MEs['eigengenes'].index)
+                print(
+                    "orderMEs: order not given, calculating using given set",
+                    str(orderBy),
+                    flush=True,
+                )
+                disPC = 1 - np.corrcoef(MEs["eigengenes"], rowvar=False)
+                disPC = pd.DataFrame(
+                    disPC,
+                    index=MEs["eigengenes"].index,
+                    columns=MEs["eigengenes"].index,
+                )
                 order = WGCNA.clustOrder(disPC, greyLast=greyLast, greyName=greyName)
-            if len(order) != MEs['eigengenes'].shape[1]:
+            if len(order) != MEs["eigengenes"].shape[1]:
                 sys.exit("orderMEs: given MEs and order have incompatible dimensions.")
             orderedMEs = MEs.copy()
-            orderedMEs['eigengenes'] = pd.DataFrame(MEs['eigengenes'][:, order])
-            orderedMEs['eigengenes'].columns = MEs['eigengenes'].columns[order]
-            if MEs['averageExpr'] is not None:
-                orderedMEs['averageExpr'] = pd.DataFrame(MEs['averageExpr'][:, order])
-                orderedMEs['averageExpr'].columns = MEs['eigengenes'].columns[order]
+            orderedMEs["eigengenes"] = pd.DataFrame(MEs["eigengenes"][:, order])
+            orderedMEs["eigengenes"].columns = MEs["eigengenes"].columns[order]
+            if MEs["averageExpr"] is not None:
+                orderedMEs["averageExpr"] = pd.DataFrame(MEs["averageExpr"][:, order])
+                orderedMEs["averageExpr"].columns = MEs["eigengenes"].columns[order]
 
-            if MEs['varExplained'] is not None:
-                orderedMEs['varExplained'] = pd.DataFrame(MEs['varExplained'][:, order])
-                orderedMEs['varExplained'].columns = MEs['eigengenes'].columns[order]
+            if MEs["varExplained"] is not None:
+                orderedMEs["varExplained"] = pd.DataFrame(MEs["varExplained"][:, order])
+                orderedMEs["varExplained"].columns = MEs["eigengenes"].columns[order]
             return orderedMEs
         else:
             check = WGCNA.checkSets(MEs, checkStructure=True, useSets=useSets)
-            if check['structureOK']:
+            if check["structureOK"]:
                 multiSet = True
             else:
                 multiSet = False
@@ -2442,31 +3073,50 @@ class WGCNA(GeneExp):
                 if useSets.index(orderBy) is None:
                     orderBy = useSets[1]
             if order is None:
-                print("orderMEs: order not given, calculating using given set", str(orderBy), flush=True)
-                disPC = 1 - np.corrcoef(MEs[orderBy]['data'], rowvar=False)
-                disPC = pd.DataFrame(disPC, index=MEs[orderBy]['data'].columns, columns=MEs[orderBy]['data'].columns)
+                print(
+                    "orderMEs: order not given, calculating using given set",
+                    str(orderBy),
+                    flush=True,
+                )
+                disPC = 1 - np.corrcoef(MEs[orderBy]["data"], rowvar=False)
+                disPC = pd.DataFrame(
+                    disPC,
+                    index=MEs[orderBy]["data"].columns,
+                    columns=MEs[orderBy]["data"].columns,
+                )
                 order = WGCNA.clustOrder(disPC, greyLast=greyLast, greyName=greyName)
-            if len(order) != MEs[orderBy]['data'].shape[1]:
+            if len(order) != MEs[orderBy]["data"].shape[1]:
                 sys.exit("orderMEs: given MEs and order have incompatible dimensions.")
             nSets = len(MEs)
             orderedMEs = MEs.copy()
             if useSets is None:
                 useSets = list(range(nSets))
             for set in useSets:
-                orderedMEs[set]['data'] = MEs[set]['data'].iloc[:, order]
+                orderedMEs[set]["data"] = MEs[set]["data"].iloc[:, order]
                 if "averageExpr" in MEs[set].keys():
-                    if MEs[set]['averageExpr'] is not None:
-                        orderedMEs[set]['averageExpr'] = MEs[set]['averageExpr'].iloc[:, order]
+                    if MEs[set]["averageExpr"] is not None:
+                        orderedMEs[set]["averageExpr"] = MEs[set]["averageExpr"].iloc[
+                            :, order
+                        ]
                 if "varExplained" in MEs[set].keys():
-                    if MEs[set]['varExplained'] is not None:
-                        orderedMEs[set]['varExplained'] = MEs[set]['varExplained'].iloc[:, order]
+                    if MEs[set]["varExplained"] is not None:
+                        orderedMEs[set]["varExplained"] = MEs[set]["varExplained"].iloc[
+                            :, order
+                        ]
             if multiSet:
                 return orderedMEs
             else:
-                return orderedMEs[0]['data']
+                return orderedMEs[0]["data"]
 
     @staticmethod
-    def consensusOrderMEs(MEs, useAbs=False, useSets=None, greyLast=True, greyName="MEgrey", method="consensus"):
+    def consensusOrderMEs(
+        MEs,
+        useAbs=False,
+        useSets=None,
+        greyLast=True,
+        greyName="MEgrey",
+        method="consensus",
+    ):
         """
         Reorder given (eigen-)vectors such that similar ones (as measured by correlation) are next to each other.
 
@@ -2486,9 +3136,13 @@ class WGCNA(GeneExp):
         :return: A dictionary of the same type as MEs containing the re-ordered eigengenes
         :rtype: dict
         """
-        Diss = WGCNA.consensusMEDissimilarityMajor(MEs, useAbs=useAbs, useSets=useSets, method=method)
+        Diss = WGCNA.consensusMEDissimilarityMajor(
+            MEs, useAbs=useAbs, useSets=useSets, method=method
+        )
         order = WGCNA.clustOrder(Diss, greyLast, greyName)
-        MEs = WGCNA.orderMEs(MEs, greyLast=greyLast, greyName=greyName, order=order, useSets=useSets)
+        MEs = WGCNA.orderMEs(
+            MEs, greyLast=greyLast, greyName=greyName, order=order, useSets=useSets
+        )
         return MEs
 
     @staticmethod
@@ -2506,11 +3160,19 @@ class WGCNA(GeneExp):
         return out
 
     @staticmethod
-    def consensusMEDissimilarity(multiMEs, useSets=None, equalizeQuantiles=False, quantileSummary="mean",
-                                 corOptions={}, consensusQuantile=0, useAbs=False, greyName="ME0"):
-        nSets = WGCNA.checkSets(multiMEs)['nSets']
-        useMEs = np.where(multiMEs[0]['data'].columns != greyName)[0].tolist()
-        useNames = multiMEs[0]['data'].columns[useMEs]
+    def consensusMEDissimilarity(
+        multiMEs,
+        useSets=None,
+        equalizeQuantiles=False,
+        quantileSummary="mean",
+        corOptions={},
+        consensusQuantile=0,
+        useAbs=False,
+        greyName="ME0",
+    ):
+        nSets = WGCNA.checkSets(multiMEs)["nSets"]
+        useMEs = np.where(multiMEs[0]["data"].columns != greyName)[0].tolist()
+        useNames = multiMEs[0]["data"].columns[useMEs]
         nUseMEs = len(useMEs)
         if useSets is None:
             useSets = list(range(nSets))
@@ -2518,12 +3180,14 @@ class WGCNA(GeneExp):
         MEDiss = np.zeros((nUseMEs, nUseMEs, nUseSets))
         MEDiss[:, :, :] = np.nan
         for set in useSets:
-            corOptions['x'] = multiMEs[set]['data'].iloc[:, useMEs]
+            corOptions["x"] = multiMEs[set]["data"].iloc[:, useMEs]
             if useAbs:
-                diss = 1 - np.abs(np.corrcoef(corOptions['x'], rowvar=False))
+                diss = 1 - np.abs(np.corrcoef(corOptions["x"], rowvar=False))
             else:
-                diss = 1 - np.corrcoef(corOptions['x'], rowvar=False)
-            diss = pd.DataFrame(diss, index=corOptions['x'].columns, columns=corOptions['x'].columns)
+                diss = 1 - np.corrcoef(corOptions["x"], rowvar=False)
+            diss = pd.DataFrame(
+                diss, index=corOptions["x"].columns, columns=corOptions["x"].columns
+            )
             MEDiss[:, :, set] = diss
         if equalizeQuantiles:
             distMat = pd.DataFrame()
@@ -2531,12 +3195,17 @@ class WGCNA(GeneExp):
                 distMat[i] = pdist(MEDiss[:, :, i])
             # distMat = apply(MEDiss, 3, function(x) { as.numeric( as.dist(x))})
             # TODO: checkdistMat.shape = [nUseMEs * (nUseMEs - 1) / 2, nUseSets]
-            normalized = WGCNA.equalizeQuantilesFun(distMat, summaryType=quantileSummary)
+            normalized = WGCNA.equalizeQuantilesFun(
+                distMat, summaryType=quantileSummary
+            )
             # TODO:apply(normalized, 2, .turnDistVectorIntoMatrix, size = nUseMEs, Diag = FALSE, Upper = FALSE, diagValue = 0)
             MEDiss = normalized
             np.fill_diagonal(normalized, 0)
-        ConsDiss = pd.DataFrame(np.quantile(MEDiss, q=1 - consensusQuantile, axis=2), index=useNames.unique(),
-                                columns=useNames.unique())
+        ConsDiss = pd.DataFrame(
+            np.quantile(MEDiss, q=1 - consensusQuantile, axis=2),
+            index=useNames.unique(),
+            columns=useNames.unique(),
+        )
         return ConsDiss
 
     @staticmethod
@@ -2545,14 +3214,32 @@ class WGCNA(GeneExp):
         NOnBranches = pd.DataFrame(Branches).value_counts()
         TrueBranch = NOnBranches >= minSize
         if len(np.where(np.logical_not(TrueBranch.iloc[Branches]))[0].tolist()) != 0:
-            Branches[np.where(np.logical_not(TrueBranch.iloc[Branches]))[0].tolist()] = 0
+            Branches[
+                np.where(np.logical_not(TrueBranch.iloc[Branches]))[0].tolist()
+            ] = 0
         return Branches
 
     @staticmethod
-    def mergeCloseModules(exprData, colors, MEs=None, useSets=None, impute=True, checkDataFormat=True,
-                          unassdColor="grey", useAbs=False, equalizeQuantiles=False, quantileSummary="mean",
-                          consensusQuantile=0, cutHeight=0.2, iterate=True, relabel=False, colorSeq=None,
-                          getNewMEs=True, getNewUnassdME=True, trapErrors=False):
+    def mergeCloseModules(
+        exprData,
+        colors,
+        MEs=None,
+        useSets=None,
+        impute=True,
+        checkDataFormat=True,
+        unassdColor="grey",
+        useAbs=False,
+        equalizeQuantiles=False,
+        quantileSummary="mean",
+        consensusQuantile=0,
+        cutHeight=0.2,
+        iterate=True,
+        relabel=False,
+        colorSeq=None,
+        getNewMEs=True,
+        getNewUnassdME=True,
+        trapErrors=False,
+    ):
         """
         Merges modules in gene expression networks that are too close as measured by the correlation of their eigengenes.
 
@@ -2601,57 +3288,100 @@ class WGCNA(GeneExp):
         MEsInSingleFrame = False
         origColors = colors
         greyName = "ME" + unassdColor
-        print("mergeCloseModules: Merging modules whose distance is less than", str(cutHeight), flush=True)
-        if not WGCNA.checkSets(exprData, checkStructure=True, useSets=useSets)['structureOK']:
+        print(
+            "mergeCloseModules: Merging modules whose distance is less than",
+            str(cutHeight),
+            flush=True,
+        )
+        if not WGCNA.checkSets(exprData, checkStructure=True, useSets=useSets)[
+            "structureOK"
+        ]:
             if checkDataFormat:
                 exprData = WGCNA.fixDataStructure(exprData)
                 MEsInSingleFrame = True
             else:
                 sys.exit("Given exprData appear to be misformatted.")
         setsize = WGCNA.checkSets(exprData, useSets=useSets)
-        nSets = setsize['nSets']
+        nSets = setsize["nSets"]
         if MEs is not None:
             checkMEs = WGCNA.checkSets(MEs, checkStructure=True, useSets=useSets)
-            if checkMEs['structureOK']:
-                if setsize['nSets'] != checkMEs['nSets']:
+            if checkMEs["structureOK"]:
+                if setsize["nSets"] != checkMEs["nSets"]:
                     sys.exit("Input error: numbers of sets in exprData and MEs differ.")
                 for set in range(nSets):
-                    if checkMEs['nSamples'][set] != setsize['nSamples'][set]:
-                        sys.exit(("Number of samples in MEs is incompatible with subset length for set", str(set)))
+                    if checkMEs["nSamples"][set] != setsize["nSamples"][set]:
+                        sys.exit(
+                            (
+                                "Number of samples in MEs is incompatible with subset length for set",
+                                str(set),
+                            )
+                        )
             else:
                 if MEsInSingleFrame:
                     MEs = WGCNA.fixDataStructure(MEs)
                     checkMEs = WGCNA.checkSets(MEs)
                 else:
-                    sys.exit("MEs do not have the appropriate structure (same as exprData). ")
-        if setsize['nGenes'] != len(colors):
-            sys.exit("Number of genes in exprData is different from the length of original colors. They must equal.")
+                    sys.exit(
+                        "MEs do not have the appropriate structure (same as exprData). "
+                    )
+        if setsize["nGenes"] != len(colors):
+            sys.exit(
+                "Number of genes in exprData is different from the length of original colors. They must equal."
+            )
         if cutHeight < 0 or cutHeight > 1 + int(useAbs):
-            sys.exit(("Given cutHeight is out of sensible range between 0 and", 1 + int(useAbs)))
+            sys.exit(
+                (
+                    "Given cutHeight is out of sensible range between 0 and",
+                    1 + int(useAbs),
+                )
+            )
         done = False
         iteration = 1
         MergedColors = colors
         try:
             while not done:
                 if MEs is None:
-                    MEs = WGCNA.multiSetMEs(exprData, colors=None, universalColors=colors, useSets=useSets,
-                                            impute=impute, subHubs=True, trapErrors=False, excludeGrey=True,
-                                            grey=unassdColor)
-                    MEs = WGCNA.consensusOrderMEs(MEs, useAbs=useAbs, useSets=useSets, greyLast=False)
-                elif len(pd.Categorical(colors).codes) != checkMEs['nGenes']:
+                    MEs = WGCNA.multiSetMEs(
+                        exprData,
+                        colors=None,
+                        universalColors=colors,
+                        useSets=useSets,
+                        impute=impute,
+                        subHubs=True,
+                        trapErrors=False,
+                        excludeGrey=True,
+                        grey=unassdColor,
+                    )
+                    MEs = WGCNA.consensusOrderMEs(
+                        MEs, useAbs=useAbs, useSets=useSets, greyLast=False
+                    )
+                elif len(pd.Categorical(colors).codes) != checkMEs["nGenes"]:
                     if iteration == 1:
                         print(
                             "Number of given module colors does not match number of given MEs => recalculating the MEs.",
-                            flush=True)
-                    MEs = WGCNA.multiSetMEs(exprData, colors=None, universalColors=colors, useSets=useSets,
-                                            impute=impute, subHubs=True, trapErrors=False, excludeGrey=True,
-                                            grey=unassdColor)
-                    MEs = WGCNA.consensusOrderMEs(MEs, useAbs=useAbs, useSets=useSets, greyLast=False)
+                            flush=True,
+                        )
+                    MEs = WGCNA.multiSetMEs(
+                        exprData,
+                        colors=None,
+                        universalColors=colors,
+                        useSets=useSets,
+                        impute=impute,
+                        subHubs=True,
+                        trapErrors=False,
+                        excludeGrey=True,
+                        grey=unassdColor,
+                    )
+                    MEs = WGCNA.consensusOrderMEs(
+                        MEs, useAbs=useAbs, useSets=useSets, greyLast=False
+                    )
                 if iteration == 1:
                     oldMEs = MEs
                 colLevs = pd.Categorical(colors)
                 if len(colLevs[colLevs != str(unassdColor)]) < 2:
-                    print("mergeCloseModules: less than two proper modules.", flush=True)
+                    print(
+                        "mergeCloseModules: less than two proper modules.", flush=True
+                    )
                     print(" ..color levels are", colLevs, flush=True)
                     print(" ..there is nothing to merge.", flush=True)
                     MergedNewColors = colors
@@ -2662,10 +3392,15 @@ class WGCNA(GeneExp):
                     Tree = None
                     break
                 nOldMods = len(pd.Categorical(colors).categories)
-                ConsDiss = WGCNA.consensusMEDissimilarity(MEs, equalizeQuantiles=equalizeQuantiles,
-                                                          quantileSummary=quantileSummary,
-                                                          consensusQuantile=consensusQuantile, useAbs=useAbs,
-                                                          useSets=useSets, greyName=greyName)
+                ConsDiss = WGCNA.consensusMEDissimilarity(
+                    MEs,
+                    equalizeQuantiles=equalizeQuantiles,
+                    quantileSummary=quantileSummary,
+                    consensusQuantile=consensusQuantile,
+                    useAbs=useAbs,
+                    useSets=useSets,
+                    greyName=greyName,
+                )
                 a = squareform(ConsDiss, checks=False)
                 Tree = WGCNA.hclust(a, method="average")
                 if iteration == 1:
@@ -2679,12 +3414,15 @@ class WGCNA(GeneExp):
                 for branch in range(nBranches):
                     if NumberOnBranch[branch] > 1:
                         ModulesOnThisBranch = TreeBranches.columns[
-                            np.where(TreeBranches == UniqueBranches[branch])[1].tolist()]
+                            np.where(TreeBranches == UniqueBranches[branch])[1].tolist()
+                        ]
                         ColorsOnThisBranch = [x[2:] for x in ModulesOnThisBranch]
                         if all(isinstance(x, int) for x in origColors):
                             ColorsOnThisBranch = [int(x) for x in ColorsOnThisBranch]
                         for color in range(1, len(ColorsOnThisBranch)):
-                            MergedColors[MergedColors == ColorsOnThisBranch[color]] = ColorsOnThisBranch[0]
+                            MergedColors[MergedColors == ColorsOnThisBranch[color]] = (
+                                ColorsOnThisBranch[0]
+                            )
                 # MergedColors = MergedColors[:, drop = TRUE]
                 nNewMods = len(pd.Categorical(MergedColors).categories)
                 if nNewMods < nOldMods and iterate:
@@ -2697,12 +3435,16 @@ class WGCNA(GeneExp):
                 RawModuleColors = pd.Categorical(MergedColors).codes
                 if colorSeq is None:
                     if isinstance(int, origColors):
-                        colorSeq = list(range(len(pd.DataFrame(origColors).value_counts())))
+                        colorSeq = list(
+                            range(len(pd.DataFrame(origColors).value_counts()))
+                        )
                     else:
                         nNewColors = len(RawModuleColors)
                         colorSeq = WGCNA.labels2colors(list(range(nNewColors)))
                 nGenesInModule = pd.DataFrame(MergedColors).value_counts()
-                SortedRawModuleColors = RawModuleColors[nGenesInModule.sort(reverse=True)]
+                SortedRawModuleColors = RawModuleColors[
+                    nGenesInModule.sort(reverse=True)
+                ]
                 MergedNewColors = MergedColors
                 if isinstance(pd.Categorical, MergedNewColors):
                     MergedNewColors = str(MergedNewColors)
@@ -2710,7 +3452,9 @@ class WGCNA(GeneExp):
                 for color in range(len(SortedRawModuleColors)):
                     if SortedRawModuleColors[color] != unassdColor:
                         rank = rank + 1
-                        MergedNewColors[MergedColors == SortedRawModuleColors[color]] = colorSeq[rank]
+                        MergedNewColors[
+                            MergedColors == SortedRawModuleColors[color]
+                        ] = colorSeq[rank]
                 if isinstance(pd.Categorical, MergedColors):
                     MergedNewColors = pd.Categorical(MergedNewColors)
             else:
@@ -2719,15 +3463,33 @@ class WGCNA(GeneExp):
             if getNewMEs:
                 if nNewMods < nOldMods or relabel or getNewUnassdME:
                     print("  Calculating new MEs...", flush=True)
-                    NewMEs = WGCNA.multiSetMEs(exprData, colors=None, universalColors=MergedNewColors, useSets=useSets,
-                                               impute=impute, subHubs=True, trapErrors=False,
-                                               excludeGrey=not getNewUnassdME, grey=unassdColor)
-                    newMEs = WGCNA.consensusOrderMEs(NewMEs, useAbs=useAbs, useSets=useSets, greyLast=True,
-                                                     greyName=greyName)
-                    ConsDiss = WGCNA.consensusMEDissimilarity(newMEs, equalizeQuantiles=equalizeQuantiles,
-                                                              quantileSummary=quantileSummary,
-                                                              consensusQuantile=consensusQuantile,
-                                                              useAbs=useAbs, useSets=useSets, greyName=greyName)
+                    NewMEs = WGCNA.multiSetMEs(
+                        exprData,
+                        colors=None,
+                        universalColors=MergedNewColors,
+                        useSets=useSets,
+                        impute=impute,
+                        subHubs=True,
+                        trapErrors=False,
+                        excludeGrey=not getNewUnassdME,
+                        grey=unassdColor,
+                    )
+                    newMEs = WGCNA.consensusOrderMEs(
+                        NewMEs,
+                        useAbs=useAbs,
+                        useSets=useSets,
+                        greyLast=True,
+                        greyName=greyName,
+                    )
+                    ConsDiss = WGCNA.consensusMEDissimilarity(
+                        newMEs,
+                        equalizeQuantiles=equalizeQuantiles,
+                        quantileSummary=quantileSummary,
+                        consensusQuantile=consensusQuantile,
+                        useAbs=useAbs,
+                        useSets=useSets,
+                        greyName=greyName,
+                    )
                     if len(ConsDiss) > 1:
                         Tree = WGCNA.hclust(pdist(ConsDiss), method="average")
                     else:
@@ -2746,11 +3508,19 @@ class WGCNA(GeneExp):
             print(" --> returning unmerged modules and *no* eigengenes.", flush=True)
             print(
                 f"{WARNING}mergeCloseModules: merging of modules failed --> returning unmerged modules and *no* "
-                f"eigengenes.\n{ENDC}")
+                f"eigengenes.\n{ENDC}"
+            )
             return {"colors": origColors, "allOK": False}
         else:
-            return {"colors": MergedNewColors, "dendro": Tree, "oldDendro": oldTree, "cutHeight": cutHeight,
-                    "oldMEs": oldMEs['data'], "newMEs": newMEs['data'], "allOK": True}
+            return {
+                "colors": MergedNewColors,
+                "dendro": Tree,
+                "oldDendro": oldTree,
+                "cutHeight": cutHeight,
+                "oldMEs": oldMEs["data"],
+                "newMEs": newMEs["data"],
+                "allOK": True,
+            }
 
     def saveWGCNA(self):
         """
@@ -2758,7 +3528,7 @@ class WGCNA(GeneExp):
         """
         print(f"{BOLD}{OKBLUE}Saving WGCNA as {self.name}.p{ENDC}")
 
-        picklefile = open(f"{self.outputPath}{self.name}.p", 'wb')
+        picklefile = open(f"{self.outputPath}{self.name}.p", "wb")
         pickle.dump(self, picklefile)
         picklefile.close()
 
@@ -2780,8 +3550,7 @@ class WGCNA(GeneExp):
                 datTraits[data.columns[i]] = data.iloc[:, i]
                 org = np.unique(data.iloc[:, i]).tolist()
                 rep = list(range(len(org)))
-                datTraits.replace(to_replace=org, value=rep,
-                                  inplace=True)
+                datTraits.replace(to_replace=org, value=rep, inplace=True)
             elif len(np.unique(data.iloc[:, i])) > 2:
                 for name in np.unique(data.iloc[:, i]):
                     datTraits[name] = data.iloc[:, i]
@@ -2794,12 +3563,14 @@ class WGCNA(GeneExp):
 
         return datTraits
 
-    def module_trait_relationships_heatmap(self,
-                                           metaData,
-                                           alternative='two-sided',
-                                           figsize=None,
-                                           show=True,
-                                           file_name='module-traitRelationships'):
+    def module_trait_relationships_heatmap(
+        self,
+        metaData,
+        alternative="two-sided",
+        figsize=None,
+        show=True,
+        file_name="module-traitRelationships",
+    ):
         """
         plot topic-trait relationship heatmap
 
@@ -2816,12 +3587,12 @@ class WGCNA(GeneExp):
         """
         datTraits = self.getDatTraits(metaData)
 
-        moduleTraitCor = pd.DataFrame(index=self.MEs.columns,
-                                      columns=datTraits.columns,
-                                      dtype="float")
-        moduleTraitPvalue = pd.DataFrame(index=self.MEs.columns,
-                                         columns=datTraits.columns,
-                                         dtype="float")
+        moduleTraitCor = pd.DataFrame(
+            index=self.MEs.columns, columns=datTraits.columns, dtype="float"
+        )
+        moduleTraitPvalue = pd.DataFrame(
+            index=self.MEs.columns, columns=datTraits.columns, dtype="float"
+        )
 
         for i in self.MEs.columns:
             for j in datTraits.columns:
@@ -2834,39 +3605,68 @@ class WGCNA(GeneExp):
             self.moduleTraitPvalue = moduleTraitPvalue
 
         if figsize is None:
-            figsize = (max(20, int(moduleTraitPvalue.shape[0] * 1.5)),
-                       moduleTraitPvalue.shape[1] * 1.5)
-        fig, ax = plt.subplots(figsize=figsize, facecolor='white')
+            figsize = (
+                max(20, int(moduleTraitPvalue.shape[0] * 1.5)),
+                moduleTraitPvalue.shape[1] * 1.5,
+            )
+        fig, ax = plt.subplots(figsize=figsize, facecolor="white")
         # names
         xlabels = []
         for label in self.MEs.columns:
-            xlabels.append(label[2:].capitalize() + '(' + str(sum(self.datExpr.var['moduleColors'] == label[2:])) + ')')
+            xlabels.append(
+                label[2:].capitalize()
+                + "("
+                + str(sum(self.datExpr.var["moduleColors"] == label[2:]))
+                + ")"
+            )
         ylabels = datTraits.columns
 
         # Loop over data dimensions and create text annotations.
         tmp_cor = moduleTraitCor.T.round(decimals=2)
         tmp_pvalue = moduleTraitPvalue.T.round(decimals=3)
-        labels = (np.asarray(["{0}\n({1})".format(cor, pvalue)
-                              for cor, pvalue in zip(tmp_cor.values.flatten(),
-                                                     tmp_pvalue.values.flatten())])) \
-            .reshape(moduleTraitCor.T.shape)
+        labels = (
+            np.asarray(
+                [
+                    "{0}\n({1})".format(cor, pvalue)
+                    for cor, pvalue in zip(
+                        tmp_cor.values.flatten(), tmp_pvalue.values.flatten()
+                    )
+                ]
+            )
+        ).reshape(moduleTraitCor.T.shape)
 
         sns.set(font_scale=1.5)
-        res = sns.heatmap(moduleTraitCor.T, annot=labels, fmt="", cmap='RdBu_r',
-                          vmin=-1, vmax=1, ax=ax, annot_kws={'size': 20, "weight": "bold"},
-                          xticklabels=xlabels, yticklabels=ylabels)
-        res.set_xticklabels(res.get_xmajorticklabels(), fontsize=20, fontweight="bold", rotation=90)
+        res = sns.heatmap(
+            moduleTraitCor.T,
+            annot=labels,
+            fmt="",
+            cmap="RdBu_r",
+            vmin=-1,
+            vmax=1,
+            ax=ax,
+            annot_kws={"size": 20, "weight": "bold"},
+            xticklabels=xlabels,
+            yticklabels=ylabels,
+        )
+        res.set_xticklabels(
+            res.get_xmajorticklabels(), fontsize=20, fontweight="bold", rotation=90
+        )
         res.set_yticklabels(res.get_ymajorticklabels(), fontsize=20, fontweight="bold")
         plt.yticks(rotation=0)
-        ax.set_title(f"Module-trait Relationships heatmap for {self.name}",
-                     fontsize=30, fontweight="bold")
-        ax.set_facecolor('white')
+        ax.set_title(
+            f"Module-trait Relationships heatmap for {self.name}",
+            fontsize=30,
+            fontweight="bold",
+        )
+        ax.set_facecolor("white")
         fig.tight_layout()
         if not show:
             plt.close(fig)
         if self.save:
-            fig.savefig(f"{self.outputPath}figures/{file_name}.{self.figureType}", \
-                        bbox_inches='tight')
+            fig.savefig(
+                f"{self.outputPath}figures/{file_name}.{self.figureType}",
+                bbox_inches="tight",
+            )
 
     def getModuleName(self):
         """
@@ -2875,7 +3675,7 @@ class WGCNA(GeneExp):
         :return: name of modules
         :rtype: ndarray
         """
-        return np.unique(self.datExpr.var['moduleColors']).tolist()
+        return np.unique(self.datExpr.var["moduleColors"]).tolist()
 
     def getGeneModule(self, moduleName):
         """
@@ -2888,13 +3688,15 @@ class WGCNA(GeneExp):
         :rtype: dict
         """
         output = {}
-        moduleColors = np.unique(self.datExpr.var['moduleColors']).tolist()
+        moduleColors = np.unique(self.datExpr.var["moduleColors"]).tolist()
         if moduleName not in moduleColors:
             print(f"{WARNING}Module name(s) does not exist in {ENDC}")
             return None
         for color in moduleColors:
             if color in moduleName:
-                output[color] = self.datExpr.var[self.datExpr.var['moduleColors'] == color]
+                output[color] = self.datExpr.var[
+                    self.datExpr.var["moduleColors"] == color
+                ]
         return output
 
     def getModulesGene(self, geneIds):
@@ -2912,7 +3714,9 @@ class WGCNA(GeneExp):
 
         modules = []
         for geneId in geneIds:
-            modules.append(self.datExpr.var.moduleColors[self.datExpr.var.gene_id == geneId])
+            modules.append(
+                self.datExpr.var.moduleColors[self.datExpr.var.gene_id == geneId]
+            )
 
         if len(modules) == 1:
             modules = modules[0]
@@ -2955,103 +3759,158 @@ class WGCNA(GeneExp):
                 height_ratios.append(1)
         height_ratios.reverse()
 
-        modules = np.unique(self.datExpr.var['moduleColors']).tolist()
+        modules = np.unique(self.datExpr.var["moduleColors"]).tolist()
         if np.all(moduleName not in modules):
             print(f"{WARNING}Module name does not exist in {ENDC}")
             return None
         else:
-            heatmap = self.datExpr[:, self.datExpr.var['moduleColors'] == moduleName].to_df()
-            heatmap = (heatmap - heatmap.min(axis=0)) / (heatmap.max(axis=0) - heatmap.min(axis=0))
+            heatmap = self.datExpr[
+                :, self.datExpr.var["moduleColors"] == moduleName
+            ].to_df()
+            heatmap = (heatmap - heatmap.min(axis=0)) / (
+                heatmap.max(axis=0) - heatmap.min(axis=0)
+            )
             heatmap = heatmap.T
             a = pdist(heatmap)
             np.nan_to_num(a, copy=False)
             Z = WGCNA.hclust(a, method="average")
             # Clusterize the data
-            labels = fcluster(Z, t=0.8, criterion='distance')
+            labels = fcluster(Z, t=0.8, criterion="distance")
             # Keep the indices to sort labels
             labels_order = np.argsort(labels)
             heatmap = heatmap.iloc[labels_order, :]
-            ME = pd.DataFrame(self.datME["ME" + moduleName].values, columns=['eigengeneExp'])
-            ME['sample_name'] = self.datME.index
+            ME = pd.DataFrame(
+                self.datME["ME" + moduleName].values, columns=["eigengeneExp"]
+            )
+            ME["sample_name"] = self.datME.index
             ind = [i + 0.5 for i in range(ME.shape[0])]
 
             if len(metadata) != 0:
-                fig, axs = plt.subplots(nrows=3, ncols=2, figsize=(ME.shape[0], len(metadata) * 5),
-                                        sharex='col', gridspec_kw={
-                        'height_ratios': [len(metadata) * 0.4, len(metadata) * 0.5, len(metadata) * 1.5],
-                        'width_ratios': [20, 3]})
+                fig, axs = plt.subplots(
+                    nrows=3,
+                    ncols=2,
+                    figsize=(ME.shape[0], len(metadata) * 5),
+                    sharex="col",
+                    gridspec_kw={
+                        "height_ratios": [
+                            len(metadata) * 0.4,
+                            len(metadata) * 0.5,
+                            len(metadata) * 1.5,
+                        ],
+                        "width_ratios": [20, 3],
+                    },
+                )
 
                 gs = axs[0, 1].get_gridspec()
                 # remove the underlying axes
                 for ax in axs[:, 1]:
                     ax.remove()
                 ax_legend = fig.add_subplot(gs[:, 1])
-                ax_legend.axis('off')
-                axs_legend = gridspec.GridSpecFromSubplotSpec(len(metadata), 1,
-                                                              subplot_spec=ax_legend.get_subplotspec(),
-                                                              height_ratios=height_ratios)
+                ax_legend.axis("off")
+                axs_legend = gridspec.GridSpecFromSubplotSpec(
+                    len(metadata),
+                    1,
+                    subplot_spec=ax_legend.get_subplotspec(),
+                    height_ratios=height_ratios,
+                )
 
                 for m in metadata:
                     handles = []
                     x = ind
                     y = np.repeat(3000 * metadata.index(m), len(ind))
-                    color = sampleInfo[m].values
+                    color = list(sampleInfo[m].values)
                     if type(self.metadataColors[m]) == dict:
                         for n in list(self.metadataColors[m].keys()):
-                            color = np.where(color == n, self.metadataColors[m][n], color)
-                            patch = mpatches.Patch(color=self.metadataColors[m][n], label=n)
+                            color = [
+                                self.metadataColors[m][n] if c == n else c
+                                for c in color
+                            ]
+                            patch = mpatches.Patch(
+                                color=self.metadataColors[m][n], label=n
+                            )
                             handles.append(patch)
-                        axs[0, 0].scatter(x, y, c=color, s=1600, marker='s')
-                        ax_legend = plt.Subplot(fig, axs_legend[len(metadata) - 1 - metadata.index(m)])
+                        axs[0, 0].scatter(x, y, c=color, s=1600, marker="s")
+                        ax_legend = plt.Subplot(
+                            fig, axs_legend[len(metadata) - 1 - metadata.index(m)]
+                        )
                         ax_legend.legend(title=m, handles=handles)
-                        ax_legend.axis('off')
+                        ax_legend.axis("off")
                         fig.add_subplot(ax_legend)
                     else:
-                        axs[0, 0].scatter(x, y, c=color, cmap=self.metadataColors[m].get_cmap(),
-                                          s=1600, marker='s')
+                        axs[0, 0].scatter(
+                            x,
+                            y,
+                            c=color,
+                            cmap=self.metadataColors[m].get_cmap(),
+                            s=1600,
+                            marker="s",
+                        )
 
-                        ax_legend = plt.Subplot(fig, axs_legend[len(metadata) - 1 - metadata.index(m)])
-                        clb = fig.colorbar(mappable=self.metadataColors[m],
-                                           ax=ax_legend,
-                                           orientation='horizontal',
-                                           fraction=0.9)
+                        ax_legend = plt.Subplot(
+                            fig, axs_legend[len(metadata) - 1 - metadata.index(m)]
+                        )
+                        clb = fig.colorbar(
+                            mappable=self.metadataColors[m],
+                            ax=ax_legend,
+                            orientation="horizontal",
+                            fraction=0.9,
+                        )
                         clb.ax.set_title(m.capitalize())
-                        ax_legend.axis('off')
+                        ax_legend.axis("off")
                         fig.add_subplot(ax_legend)
 
-                axs[0, 0].set_title(f"Module Eigengene for {moduleName}", size=28, fontweight="bold")
+                axs[0, 0].set_title(
+                    f"Module Eigengene for {moduleName}", size=28, fontweight="bold"
+                )
                 axs[0, 0].set_ylim(-2000, np.max(y) + 2000)
                 axs[0, 0].grid(False)
-                axs[0, 0].axis('off')
+                axs[0, 0].axis("off")
 
-                axs[1, 0].bar(ind, ME.eigengeneExp, align='center', color='black')
-                axs[1, 0].set_ylabel('eigengeneExp')
-                axs[1, 0].set_facecolor('white')
+                axs[1, 0].bar(ind, ME.eigengeneExp, align="center", color="black")
+                axs[1, 0].set_ylabel("eigengeneExp")
+                axs[1, 0].set_facecolor("white")
 
                 cmap = sns.color_palette("dark:red", as_cmap=True)
-                sns.heatmap(heatmap, cmap=cmap,
-                            cbar=False,  # cbar_ax=axs[2,1],
-                            yticklabels=False, xticklabels=False,
-                            ax=axs[2, 0])
+                sns.heatmap(
+                    heatmap,
+                    cmap=cmap,
+                    cbar=False,  # cbar_ax=axs[2,1],
+                    yticklabels=False,
+                    xticklabels=False,
+                    ax=axs[2, 0],
+                )
             else:
-                fig, axs = plt.subplots(nrows=2, ncols=1, figsize=(ME.shape[0], 20),
-                                        sharex='col', gridspec_kw={
-                        'height_ratios': [1, 1.5]}, facecolor='white')
+                fig, axs = plt.subplots(
+                    nrows=2,
+                    ncols=1,
+                    figsize=(ME.shape[0], 20),
+                    sharex="col",
+                    gridspec_kw={"height_ratios": [1, 1.5]},
+                    facecolor="white",
+                )
 
-                axs[0].set_title(f"Module Eigengene for {moduleName}", size=28, fontweight="bold")
-                axs[0].bar(ind, ME.eigengeneExp, align='center', color='black')
-                axs[0].set_ylabel('eigengeneExp')
+                axs[0].set_title(
+                    f"Module Eigengene for {moduleName}", size=28, fontweight="bold"
+                )
+                axs[0].bar(ind, ME.eigengeneExp, align="center", color="black")
+                axs[0].set_ylabel("eigengeneExp")
 
                 cmap = sns.color_palette("dark:red", as_cmap=True)
-                sns.heatmap(heatmap, cmap=cmap,
-                            cbar=False,  # cbar_ax=axs[2,1],
-                            yticklabels=False, xticklabels=False,
-                            ax=axs[1])
+                sns.heatmap(
+                    heatmap,
+                    cmap=cmap,
+                    cbar=False,  # cbar_ax=axs[2,1],
+                    yticklabels=False,
+                    xticklabels=False,
+                    ax=axs[1],
+                )
 
             if self.save:
-                fig.savefig(f"{self.outputPath}figures/"\
-                            f"{self.name}_module_heatmap_eigengene_{moduleName}.{self.figureType}", \
-                            bbox_inches='tight')
+                fig.savefig(
+                    f"{self.outputPath}figures/"
+                    f"{self.name}_module_heatmap_eigengene_{moduleName}.{self.figureType}",
+                    bbox_inches="tight",
+                )
             if not show:
                 plt.close(fig)
             else:
@@ -3059,7 +3918,9 @@ class WGCNA(GeneExp):
 
         return None
 
-    def barplotModuleEigenGene(self, moduleName, metadata, combine=True, colorBar=None, show=True):
+    def barplotModuleEigenGene(
+        self, moduleName, metadata, combine=True, colorBar=None, show=True
+    ):
         """
         bar plot of module eigen gene figure in given module
 
@@ -3077,7 +3938,8 @@ class WGCNA(GeneExp):
         sampleInfo = self.datExpr.obs
         if sampleInfo.shape[1] == 0:
             print(
-                f"{WARNING}There is not any sample information in given object! Skip running barplotModuleEigenGene() function.{ENDC}")
+                f"{WARNING}There is not any sample information in given object! Skip running barplotModuleEigenGene() function.{ENDC}"
+            )
             return None
 
         height_ratios = []
@@ -3088,39 +3950,51 @@ class WGCNA(GeneExp):
                 height_ratios.append(1)
         height_ratios.reverse()
 
-        modules = np.unique(self.datExpr.var['moduleColors']).tolist()
+        modules = np.unique(self.datExpr.var["moduleColors"]).tolist()
         if np.all(moduleName not in modules):
             print(f"{WARNING}Module name does not exist in {ENDC}")
             return None
         else:
-            ME = pd.DataFrame(self.datME["ME" + moduleName].values, columns=['eigengeneExp'])
+            ME = pd.DataFrame(
+                self.datME["ME" + moduleName].values, columns=["eigengeneExp"]
+            )
 
             if combine:
                 df = ME.copy(deep=True)
-                df['all'] = ''
+                df["all"] = ""
                 for m in metadata:
                     df[m] = sampleInfo[m].values
                     df.sort_values(by=m, inplace=True)
-                    df[m] = df[m].astype(str).str.replace('_', '-') # Replace underscores with dashes
-                    df['all'] = df['all'] + '_' + df[m].astype(str)
-                df['all'] = df['all'].apply(lambda x: x[1:])
-                cat = pd.DataFrame(pd.unique(df['all']), columns=['all'])
-                cat[metadata] = cat['all'].str.split('_', expand=True)
-                for col in cat.columns: # switch back dashes to underscores
-                    cat[col] = cat[col].str.replace('-', '_') # switch back dashes to underscores
-                df['all'] = df['all'].astype(str).str.replace('-', '_') # switch back dashes to underscores
-                ybar = df[['all', 'eigengeneExp']].groupby(['all']).mean()['eigengeneExp']
-                ebar = df[['all', 'eigengeneExp']].groupby(['all']).std()['eigengeneExp']
-                ybar = ybar.loc[cat['all']]
-                ebar = ebar.loc[cat['all']]
+                    df[m] = (
+                        df[m].astype(str).str.replace("_", "-")
+                    )  # Replace underscores with dashes
+                    df["all"] = df["all"] + "_" + df[m].astype(str)
+                df["all"] = df["all"].apply(lambda x: x[1:])
+                cat = pd.DataFrame(pd.unique(df["all"]), columns=["all"])
+                cat[metadata] = cat["all"].str.split("_", expand=True)
+                for col in cat.columns:  # switch back dashes to underscores
+                    cat[col] = cat[col].str.replace(
+                        "-", "_"
+                    )  # switch back dashes to underscores
+                df["all"] = (
+                    df["all"].astype(str).str.replace("-", "_")
+                )  # switch back dashes to underscores
+                ybar = (
+                    df[["all", "eigengeneExp"]].groupby(["all"]).mean()["eigengeneExp"]
+                )
+                ebar = (
+                    df[["all", "eigengeneExp"]].groupby(["all"]).std()["eigengeneExp"]
+                )
+                ybar = ybar.loc[cat["all"]]
+                ebar = ebar.loc[cat["all"]]
                 label = list(ybar.index)
-                dot = df[['all', 'eigengeneExp']].copy()
+                dot = df[["all", "eigengeneExp"]].copy()
                 ind = {}
                 for i in range(cat.shape[0]):
-                    ind[cat.loc[i, 'all']] = cat.index[i]
+                    ind[cat.loc[i, "all"]] = cat.index[i]
                 dot.replace(ind, inplace=True)
-                xdot = dot['all']
-                ydot = dot['eigengeneExp']
+                xdot = dot["all"]
+                ydot = dot["eigengeneExp"]
 
                 if colorBar is None:
                     palette = "lightblue"
@@ -3130,56 +4004,87 @@ class WGCNA(GeneExp):
                     palette = palette[colorBar].values
                 else:
                     palette = cat[[colorBar]].copy()
-                    palette[[colorBar]] = palette[[colorBar]].astype('int')
-                    palette[colorBar] = palette[colorBar].apply(lambda x: mcolors.to_hex(self.metadataColors[colorBar].to_rgba(float(x))) if pd.notna(x) else "#FFFFFF")
+                    palette[[colorBar]] = palette[[colorBar]].astype("int")
+                    palette[colorBar] = palette[colorBar].apply(
+                        lambda x: mcolors.to_hex(
+                            self.metadataColors[colorBar].to_rgba(float(x))
+                        )
+                        if pd.notna(x)
+                        else "#FFFFFF"
+                    )
                     palette = palette[colorBar].values
 
-                fig, axs = plt.subplots(nrows=2, ncols=2, figsize=(cat.shape[0] + 2, len(metadata) * 4),
-                                        sharex='col', gridspec_kw={
-                        'height_ratios': [len(metadata) * 0.4, len(metadata) * 0.6],
-                        'width_ratios': [cat.shape[0], 3]})
+                fig, axs = plt.subplots(
+                    nrows=2,
+                    ncols=2,
+                    figsize=(cat.shape[0] + 2, len(metadata) * 4),
+                    sharex="col",
+                    gridspec_kw={
+                        "height_ratios": [len(metadata) * 0.4, len(metadata) * 0.6],
+                        "width_ratios": [cat.shape[0], 3],
+                    },
+                )
 
                 gs = axs[0, 1].get_gridspec()
                 # remove the underlying axes
                 for ax in axs[:, 1]:
                     ax.remove()
                 ax_legend = fig.add_subplot(gs[:, 1])
-                ax_legend.axis('off')
-                axs_legend = gridspec.GridSpecFromSubplotSpec(len(metadata), 1,
-                                                              subplot_spec=ax_legend.get_subplotspec(),
-                                                              height_ratios=height_ratios)
+                ax_legend.axis("off")
+                axs_legend = gridspec.GridSpecFromSubplotSpec(
+                    len(metadata),
+                    1,
+                    subplot_spec=ax_legend.get_subplotspec(),
+                    height_ratios=height_ratios,
+                )
 
                 ind = [i for i in range(cat.shape[0])]
                 for m in metadata:
                     handles = []
                     x = ind
                     y = np.repeat(3000 * metadata.index(m), len(ind))
-                    color = cat[m].values
+                    color = list(cat[m].values)
                     if type(self.metadataColors[m]) == dict:
                         for n in list(self.metadataColors[m].keys()):
-                            color = np.where(color == n, self.metadataColors[m][n], color)
-                            patch = mpatches.Patch(color=self.metadataColors[m][n], label=n)
+                            color = [
+                                self.metadataColors[m][n] if c == n else c
+                                for c in color
+                            ]
+                            patch = mpatches.Patch(
+                                color=self.metadataColors[m][n], label=n
+                            )
                             handles.append(patch)
                         if m != colorBar:
-                            axs[0, 0].scatter(x, y, c=color, s=1600, marker='s')
-                        ax_legend = plt.Subplot(fig, axs_legend[len(metadata) - 1 - metadata.index(m)])
+                            axs[0, 0].scatter(x, y, c=color, s=1600, marker="s")
+                        ax_legend = plt.Subplot(
+                            fig, axs_legend[len(metadata) - 1 - metadata.index(m)]
+                        )
                         ax_legend.legend(title=m, handles=handles)
-                        ax_legend.axis('off')
+                        ax_legend.axis("off")
                         fig.add_subplot(ax_legend)
                     else:
-                        cat[m] = cat[m].astype('float')
+                        cat[m] = cat[m].astype("float")
                         color = cat[m].values
-                        axs[0, 0].scatter(x, y, c=color,
-                                          cmap=self.metadataColors[m].get_cmap(),
-                                          s=1600, marker='s')
+                        axs[0, 0].scatter(
+                            x,
+                            y,
+                            c=color,
+                            cmap=self.metadataColors[m].get_cmap(),
+                            s=1600,
+                            marker="s",
+                        )
 
-                        ax_legend = plt.Subplot(fig, axs_legend[len(metadata) - 1 - metadata.index(m)])
-                        clb = fig.colorbar(mappable=self.metadataColors[m],
-                                           ax=ax_legend,
-                                           orientation='horizontal',
-                                           fraction=0.9)
+                        ax_legend = plt.Subplot(
+                            fig, axs_legend[len(metadata) - 1 - metadata.index(m)]
+                        )
+                        clb = fig.colorbar(
+                            mappable=self.metadataColors[m],
+                            ax=ax_legend,
+                            orientation="horizontal",
+                            fraction=0.9,
+                        )
                         clb.ax.set_title(m.capitalize())
-                        ax_legend.axis('off')
+                        ax_legend.axis("off")
                         fig.add_subplot(ax_legend)
                     # if m != colorBar:
                     #     axs[0, 0].scatter(x, y, c=color, s=1600, marker='s')
@@ -3188,49 +4093,66 @@ class WGCNA(GeneExp):
                     # ax_legend.axis('off')
                     # fig.add_subplot(ax_legend)
 
-                axs[0, 0].set_title(f"Module Eigengene for {moduleName}", size=28, fontweight="bold")
+                axs[0, 0].set_title(
+                    f"Module Eigengene for {moduleName}", size=28, fontweight="bold"
+                )
                 axs[0, 0].set_ylim(-2000, np.max(y) + 2000)
                 axs[0, 0].grid(False)
-                axs[0, 0].axis('off')
+                axs[0, 0].axis("off")
 
                 ind = [i for i in range(cat.shape[0])]
-                axs[1, 0].bar(ind, ybar, align='center', color=palette)
+                axs[1, 0].bar(ind, ybar, align="center", color=palette)
                 axs[1, 0].errorbar(ind, ybar, yerr=ebar, fmt="o", color="r")
-                axs[1, 0].scatter(xdot, ydot, c='black', alpha=0.5)
+                axs[1, 0].scatter(xdot, ydot, c="black", alpha=0.5)
                 axs[1, 0].set_xticks(np.arange(len(ind)))
                 axs[1, 0].set_xticklabels(label, rotation=90)
-                axs[1, 0].set_ylabel('eigengeneExp')
-                axs[1, 0].set_facecolor('white')
+                axs[1, 0].set_ylabel("eigengeneExp")
+                axs[1, 0].set_facecolor("white")
                 fig.subplots_adjust(bottom=0.3)
-                fig.savefig(f"{self.outputPath}figures/"\
-                            f"{self.name}_module_barplot_eigengene_{moduleName}.{self.figureType}", \
-                            bbox_inches='tight')
+                fig.savefig(
+                    f"{self.outputPath}figures/"
+                    f"{self.name}_module_barplot_eigengene_{moduleName}.{self.figureType}",
+                    bbox_inches="tight",
+                )
                 if not show:
                     plt.close(fig)
 
             else:
-                fig, axs = plt.subplots(nrows=1, ncols=len(metadata), figsize=(5 * len(metadata), 5))
+                fig, axs = plt.subplots(
+                    nrows=1, ncols=len(metadata), figsize=(5 * len(metadata), 5)
+                )
 
                 for i in range(len(metadata)):
                     df = ME.copy(deep=True)
                     df[metadata[i]] = sampleInfo[metadata[i]].values
                     df.sort_values(by=metadata[i], inplace=True)
                     palette = self.metadataColors[metadata[i]]
-                    bar = sns.barplot(x=metadata[i], y="eigengeneExp", data=df, palette=palette, ci='sd', capsize=0.1,
-                                      ax=axs[i])
+                    bar = sns.barplot(
+                        x=metadata[i],
+                        y="eigengeneExp",
+                        data=df,
+                        palette=palette,
+                        ci="sd",
+                        capsize=0.1,
+                        ax=axs[i],
+                    )
                     if i != 0:
                         bar.set(ylabel=None)
 
                 if self.save:
-                    fig.savefig(f"{self.outputPath}figures/"\
-                                f"{self.name}_module_barplot_eigengene_{moduleName}.{self.figureType}", \
-                                bbox_inches='tight')
+                    fig.savefig(
+                        f"{self.outputPath}figures/"
+                        f"{self.name}_module_barplot_eigengene_{moduleName}.{self.figureType}",
+                        bbox_inches="tight",
+                    )
                 if not show:
                     plt.close(fig)
                 else:
                     return axs
 
-    def functional_enrichment_analysis(self, type, moduleName, sets=None, p_value=1, file_name=None, **kwargs):
+    def functional_enrichment_analysis(
+        self, type, moduleName, sets=None, p_value=1, file_name=None, **kwargs
+    ):
         """
         Doing functional enrichment analysis including GO, KEGG and REACTOME
 
@@ -3253,13 +4175,15 @@ class WGCNA(GeneExp):
         if file_name is None:
             file_name = moduleName
 
-        modules = np.unique(self.datExpr.var['moduleColors']).tolist()
+        modules = np.unique(self.datExpr.var["moduleColors"]).tolist()
         if np.all(moduleName not in modules):
             print(f"{WARNING}Module name does not exist in {ENDC}")
             return
 
         if not os.path.exists(f"{self.outputPath}figures/{self.name}_{type}"):
-            print(f"{WARNING}{type} directory does not exist!\nCreating {self.name}_{type} directory!{ENDC}")
+            print(
+                f"{WARNING}{type} directory does not exist!\nCreating {self.name}_{type} directory!{ENDC}"
+            )
             os.makedirs(f"{self.outputPath}figures/{self.name}_{type}")
 
         if type == "GO" and sets is None:
@@ -3267,48 +4191,62 @@ class WGCNA(GeneExp):
         elif type == "KEGG" and sets is None:
             sets = ["KEGG_2016"]
 
-        geneModule = self.datExpr.var.gene_name[self.datExpr.var.moduleColors == moduleName].astype(str)
+        geneModule = self.datExpr.var.gene_name[
+            self.datExpr.var.moduleColors == moduleName
+        ].astype(str)
         geneModule = geneModule.fillna("").values.tolist()
 
         if type in ["GO", "KEGG"]:
             try:
-                enr = gp.enrichr(gene_list=geneModule,
-                                 gene_sets=sets,
-                                 organism=self.species,
-                                 outdir=f"{self.outputPath}figures/{self.name}_{type}/{file_name}",
-                                 cutoff=p_value,
-                                 **kwargs)
-                dotplot(enr.res2d,
-                        title=f"Gene ontology in {moduleName} module",
-                        cmap='viridis_r',
-                        cutoff=p_value,
-                        ofname=f"{self.outputPath}figures/{self.name}_{type}/{file_name}.{self.figureType}")
+                enr = gp.enrichr(
+                    gene_list=geneModule,
+                    gene_sets=sets,
+                    organism=self.species,
+                    outdir=f"{self.outputPath}figures/{self.name}_{type}/{file_name}",
+                    cutoff=p_value,
+                    **kwargs,
+                )
+                dotplot(
+                    enr.res2d,
+                    title=f"Gene ontology in {moduleName} module",
+                    cmap="viridis_r",
+                    cutoff=p_value,
+                    ofname=f"{self.outputPath}figures/{self.name}_{type}/{file_name}.{self.figureType}",
+                )
             except:
                 print(f"No enrich terms when cutoff = {p_value} in module {moduleName}")
         else:
             numGeneModule = len(geneModule)
             geneModule = ",".join(geneModule)
-            result = analysis.identifiers(ids=geneModule,
-                                          species=self.species,
-                                          p_value=str(p_value))
-            token = result['summary']['token']
-            analysis.report(token,
-                            path=f"{self.outputPath}figures/{self.name}_{type}/",
-                            file=f"{file_name}.{self.figureType}",
-                            number='50',
-                            species=self.species)
-            token_result = analysis.token(token,
-                                          species=self.species,
-                                          p_value=str(p_value))
+            result = analysis.identifiers(
+                ids=geneModule, species=self.species, p_value=str(p_value)
+            )
+            token = result["summary"]["token"]
+            analysis.report(
+                token,
+                path=f"{self.outputPath}figures/{self.name}_{type}/",
+                file=f"{file_name}.{self.figureType}",
+                number="50",
+                species=self.species,
+            )
+            token_result = analysis.token(
+                token, species=self.species, p_value=str(p_value)
+            )
 
             print(
-                f"{numGeneModule - token_result['identifiersNotFound']} out of {numGeneModule} genes (identifiers) in the sample were found in Reactome.")
+                f"{numGeneModule - token_result['identifiersNotFound']} out of {numGeneModule} genes (identifiers) in the sample were found in Reactome."
+            )
             print(
-                f"{token_result['resourceSummary'][0]['pathways']} pathways were hit by at least one of them, which {len(token_result['pathways'])} of them have p-value less than {p_value}.")
-            print(f"Report was saved {self.outputPath}figures/{self.name}_{type}/{file_name}.{self.figureType}!")
-            print(f"For more information please visit https://reactome.org/PathwayBrowser/#/DTAB=AN&ANALYSIS={token}")
+                f"{token_result['resourceSummary'][0]['pathways']} pathways were hit by at least one of them, which {len(token_result['pathways'])} of them have p-value less than {p_value}."
+            )
+            print(
+                f"Report was saved {self.outputPath}figures/{self.name}_{type}/{file_name}.{self.figureType}!"
+            )
+            print(
+                f"For more information please visit https://reactome.org/PathwayBrowser/#/DTAB=AN&ANALYSIS={token}"
+            )
 
-    def updateGeneInfo(self, geneInfo=None, path=None, sep=','):
+    def updateGeneInfo(self, geneInfo=None, path=None, sep=","):
         """
         add/update genes info in datExpr and geneExpr anndata
 
@@ -3323,7 +4261,7 @@ class WGCNA(GeneExp):
         self.geneExpr = GeneExp.updateGeneInfo(self.geneExpr, geneInfo, path, sep)
         self.datExpr = GeneExp.updateGeneInfo(self.datExpr, geneInfo, path, sep)
 
-    def updateSampleInfo(self, sampleInfo=None, path=None, sep=','):
+    def updateSampleInfo(self, sampleInfo=None, path=None, sep=","):
         """
         add/update metadata in datExpr and geneExpr anndata
 
@@ -3339,8 +4277,15 @@ class WGCNA(GeneExp):
         self.datExpr = GeneExp.updateSampleInfo(self.datExpr, sampleInfo, path, sep)
 
     @staticmethod
-    def softConnectivity(datExpr, corOptions=pd.DataFrame(), weights=None, type="unsigned", power=6, blockSize=1500,
-                         minNSamples=None):
+    def softConnectivity(
+        datExpr,
+        corOptions=pd.DataFrame(),
+        weights=None,
+        type="unsigned",
+        power=6,
+        blockSize=1500,
+        minNSamples=None,
+    ):
         """
         Given expression data or a similarity, the function constructs the adjacency matrix and for each node calculates its connectivity, that is the sum of the adjacency to the other nodes.
 
@@ -3378,19 +4323,27 @@ class WGCNA(GeneExp):
             sys.exit(
                 f"Error: Something seems to be wrong. \n Make sure that the input data frame has genes as rows and "
                 f"array samples as columns.\n Alternatively, there seem to be fewer than 10 genes or fewer than "
-                f"{minNSamples} samples.")
+                f"{minNSamples} samples."
+            )
         if nGenes < nSamples:
             print(
                 f"{WARNING}Warning: There are fewer genes than samples in the function softConnectivity. Maybe you "
-                f"should transpose the data?{ENDC}")
+                f"should transpose the data?{ENDC}"
+            )
 
         k = np.zeros((nGenes,))
         start = 1
         while start < nGenes:
             end = min(start + blockSize - 1, nGenes)
             index1 = range(start, end)
-            ad1 = WGCNA.adjacency(datExpr, weights=weights, selectCols=index1, power=power, adjacencyType=type,
-                                  corOptions=corOptions)
+            ad1 = WGCNA.adjacency(
+                datExpr,
+                weights=weights,
+                selectCols=index1,
+                power=power,
+                adjacencyType=type,
+                corOptions=corOptions,
+            )
             k[index1] = ad1.sum(axis=1) - 1
             # If fewer than minNSamples contain gene expression information for a given
             # gene, then we set its connectivity to 0.
@@ -3421,7 +4374,9 @@ class WGCNA(GeneExp):
             sys.exit("input matrix is not a square matrix.")
 
         if mat.shape[0] != len(colors):
-            sys.exit("Dimensions of matrix (number of genes) and length of 'colors' differ.")
+            sys.exit(
+                "Dimensions of matrix (number of genes) and length of 'colors' differ."
+            )
 
         nNodes = len(colors)
         colorLevels = pd.Categorical(colors).categories
@@ -3444,7 +4399,9 @@ class WGCNA(GeneExp):
         if scaleByMax:
             kOut = np.zeros((nNodes,))
         kDiff = np.subtract(kWithin, kOut)
-        res = pd.DataFrame({'kTotal': kTotal, 'kWithin': kWithin, 'kOut': kOut, 'kDiff': kDiff})
+        res = pd.DataFrame(
+            {"kTotal": kTotal, "kWithin": kWithin, "kOut": kOut, "kDiff": kDiff}
+        )
         if index is not None:
             res.index = index
         return res
@@ -3463,21 +4420,29 @@ class WGCNA(GeneExp):
         """
         corOptions = []
         if self.datME.shape[0] != self.datExpr.to_df().shape[0]:
-            sys.exit("Number of samples (rows) in 'datExpr' and 'datME' must be the same.")
+            sys.exit(
+                "Number of samples (rows) in 'datExpr' and 'datME' must be the same."
+            )
         datExpr = self.datExpr.to_df()
         datME = self.datME
         if exprWeights is not None:
-            exprWeights = WGCNA.checkAndScaleWeights(exprWeights, datExpr, scaleByMax=False)
+            exprWeights = WGCNA.checkAndScaleWeights(
+                exprWeights, datExpr, scaleByMax=False
+            )
         if MEWeights is not None:
             MEWeights = WGCNA.checkAndScaleWeights(exprWeights, datME, scaleByMax=False)
 
         varianceZeroIndicatordatExpr = sum(datExpr.var(axis=0) == 0)
         varianceZeroIndicatordatME = sum(datME.var(axis=0) == 0)
         if varianceZeroIndicatordatExpr > 0:
-            print(f"{WARNING}Some genes are constant. Hint: consider removing constant columns from datExpr.{ENDC}")
+            print(
+                f"{WARNING}Some genes are constant. Hint: consider removing constant columns from datExpr.{ENDC}"
+            )
         if varianceZeroIndicatordatME > 0:
-            print(f"{WARNING}Some module eigengenes are constant, which is suspicious. Hint: consider removing "
-                  f"constant columns from datME.{ENDC}")
+            print(
+                f"{WARNING}Some module eigengenes are constant, which is suspicious. Hint: consider removing "
+                f"constant columns from datME.{ENDC}"
+            )
         if MEWeights is not None:
             corOptions.append("weights.y = MEWeights, ")
         if exprWeights is not None:
@@ -3486,10 +4451,21 @@ class WGCNA(GeneExp):
         output = np.corrcoef(datExpr.T, datME.T)
         tmp = len(datME.columns)
         col = ["k" + datME.columns[i] for i in range(tmp)]
-        self.signedKME = pd.DataFrame(output[0:datExpr.shape[1], datExpr.shape[1]:],
-                                      index=datExpr.columns, columns=col)
+        self.signedKME = pd.DataFrame(
+            output[0 : datExpr.shape[1], datExpr.shape[1] :],
+            index=datExpr.columns,
+            columns=col,
+        )
 
-    def CoexpressionModulePlot(self, modules, numGenes=10, numConnections=100, minTOM=0, filters=None, file_name=None):
+    def CoexpressionModulePlot(
+        self,
+        modules,
+        numGenes=10,
+        numConnections=100,
+        minTOM=0,
+        filters=None,
+        file_name=None,
+    ):
         """
         plot Coexpression for given module
 
@@ -3512,7 +4488,9 @@ class WGCNA(GeneExp):
             print("signedKME is empty! call signedKME() to calculate it")
 
         if not os.path.exists(f"{self.outputPath}figures/network/"):
-            print(f"{WARNING}Network directory does not exist!\nCreating network directory!{ENDC}")
+            print(
+                f"{WARNING}Network directory does not exist!\nCreating network directory!{ENDC}"
+            )
             os.makedirs(f"{self.outputPath}figures/network/")
 
         gene_id = self.datExpr.var.loc[self.datExpr.var.moduleColors.isin(modules), :]
@@ -3526,7 +4504,9 @@ class WGCNA(GeneExp):
             numConnections = numGenes * (numGenes - 1)
         genes = []
         for module in modules:
-            mat = self.signedKME.loc[gene_id.index].sort_values(["kME" + module], ascending=False)
+            mat = self.signedKME.loc[gene_id.index].sort_values(
+                ["kME" + module], ascending=False
+            )
             mat = mat.iloc[:numGenes, :]
             genes = genes + mat.index.tolist()
 
@@ -3538,37 +4518,53 @@ class WGCNA(GeneExp):
         adj = adj.stack().nlargest(numConnections)
 
         net = Network()
-        gene_id = list(adj.index.get_level_values(0)) + list(adj.index.get_level_values(1))
+        gene_id = list(adj.index.get_level_values(0)) + list(
+            adj.index.get_level_values(1)
+        )
         gene_id = np.unique(gene_id)
         nodes = self.datExpr.var.loc[gene_id, :]
         node_color = nodes["moduleColors"].tolist()
-        nodes.drop(["dynamicColors", "moduleColors", "moduleLabels"], axis=1, inplace=True)
+        nodes.drop(
+            ["dynamicColors", "moduleColors", "moduleLabels"], axis=1, inplace=True
+        )
         title = nodes.index.tolist()
         for i in range(nodes.shape[0]):
             for j in range(nodes.shape[1]):
                 if not pd.isna(nodes.iloc[i, j]):
-                    title[i] = title[i] + "\n" + str(nodes.columns[j]) + ": " + str(nodes.iloc[i, j])
+                    title[i] = (
+                        title[i]
+                        + "\n"
+                        + str(nodes.columns[j])
+                        + ": "
+                        + str(nodes.iloc[i, j])
+                    )
 
-        net.add_nodes(nodes.index.tolist(),
-                      title=title,
-                      label=nodes.index.tolist(),
-                      color=node_color)
+        net.add_nodes(
+            nodes.index.tolist(),
+            title=title,
+            label=nodes.index.tolist(),
+            color=node_color,
+        )
 
         for i in range(len(adj)):
             if adj[i] != 0:
-                net.add_edge(adj.index.get_level_values(0)[i],
-                             adj.index.get_level_values(1)[i],
-                             weight=adj[i])
+                net.add_edge(
+                    adj.index.get_level_values(0)[i],
+                    adj.index.get_level_values(1)[i],
+                    weight=adj[i],
+                )
 
         if file_name is None:
             if len(modules) <= 3:
-                file_name = '_'.join(modules)
+                file_name = "_".join(modules)
             else:
                 file_name = "network"
 
         net.show(f"{self.outputPath}figures/network/{file_name}.html")
 
-    def PPI_network(self, species, moduleName=None, geneList=None, output_format="image"):
+    def PPI_network(
+        self, species, moduleName=None, geneList=None, output_format="image"
+    ):
         """
         retrieve an image of a STRING network of a neighborhood surrounding one or more proteins or ask STRING to show only the network of interactions between your input proteins.
 
@@ -3592,7 +4588,9 @@ class WGCNA(GeneExp):
             sys.exit("geneList or moduleName should be empty at the same time!")
 
         if not os.path.exists(f"{self.outputPath}figures/PPI/"):
-            print(f"{WARNING}PPI directory does not exist!\nCreating PPI directory!{ENDC}")
+            print(
+                f"{WARNING}PPI directory does not exist!\nCreating PPI directory!{ENDC}"
+            )
             os.makedirs(f"{self.outputPath}figures/PPI/")
 
         res = WGCNA.request_PPI(genes=geneList, species=species)
@@ -3612,18 +4610,21 @@ class WGCNA(GeneExp):
                 "species": species,  # species NCBI identifier
                 "add_white_nodes": 15,  # add 15 white nodes to my protein
                 "network_flavor": "confidence",  # show confidence links
-                "caller_identity": "www.awesome_app.org"  # your app name
-
+                "caller_identity": "www.awesome_app.org",  # your app name
             }
-            WGCNA.request_PPI_image(params=params,
-                                    genes=genes,
-                                    file_name=f"{self.outputPath}figures/PPI/{tmp.gene1.tolist()[0]}_PPI.png",
-                                    request_url=request_url)
+            WGCNA.request_PPI_image(
+                params=params,
+                genes=genes,
+                file_name=f"{self.outputPath}figures/PPI/{tmp.gene1.tolist()[0]}_PPI.png",
+                request_url=request_url,
+            )
         return res
 
     @staticmethod
-    def request_PPI_subset(params,
-                           request_url='https://version-11-5.string-db.org/api/tsv-no-header/interaction_partners'):
+    def request_PPI_subset(
+        params,
+        request_url="https://version-11-5.string-db.org/api/tsv-no-header/interaction_partners",
+    ):
         """
         request STRING to find genes interact with our gene list base
 
@@ -3642,7 +4643,9 @@ class WGCNA(GeneExp):
             for line in response.text.strip().split("\n"):
                 l = line.strip().split("\t")
 
-                tmp = pd.DataFrame({'gene1': l[2], 'gene2': l[3], 'score': l[5]}, index=[0])
+                tmp = pd.DataFrame(
+                    {"gene1": l[2], "gene2": l[3], "score": l[5]}, index=[0]
+                )
                 res = pd.concat([res, tmp], ignore_index=True)
 
         sleep(1)
@@ -3650,8 +4653,7 @@ class WGCNA(GeneExp):
         return res
 
     @staticmethod
-    def request_PPI(genes,
-                    species):
+    def request_PPI(genes, species):
         """
         Getting all the STRING interaction partners of the protein set
 
@@ -3673,31 +4675,34 @@ class WGCNA(GeneExp):
         count = 0
         res = pd.DataFrame(columns=["gene1", "gene2", "score"])
         while count < len(genes):
-
             if count + 2000 > len(genes):
                 my_genes = genes[count:]
             else:
-                my_genes = genes[count:count + 2000]
+                my_genes = genes[count : count + 2000]
 
             params = {
                 "identifiers": "%0d".join(my_genes),  # your protein
                 "species": species,  # species NCBI identifier
                 "limit": 5,
-                "caller_identity": "www.awesome_app.org"  # your app name
+                "caller_identity": "www.awesome_app.org",  # your app name
             }
 
             tmp = WGCNA.request_PPI_subset(params, request_url)
             count = count + 2000
             res = pd.concat([res, tmp], ignore_index=True)
 
-        print(f"{len(res.gene1.unique().tolist())} genes out of {len(genes)} genes have PPI.")
+        print(
+            f"{len(res.gene1.unique().tolist())} genes out of {len(genes)} genes have PPI."
+        )
         return res
 
     @staticmethod
-    def request_PPI_image(params,
-                          genes,
-                          file_name,
-                          request_url='https://version-11-5.string-db.org/api/image/network'):
+    def request_PPI_image(
+        params,
+        genes,
+        file_name,
+        request_url="https://version-11-5.string-db.org/api/image/network",
+    ):
         """
         plot PPI interaction along with link that direct you to the STRING webpage
 
@@ -3716,12 +4721,14 @@ class WGCNA(GeneExp):
         if response.status_code == 200:
             print("Saving interaction network to %s" % file_name)
 
-            with open(file_name, 'wb') as fh:
+            with open(file_name, "wb") as fh:
                 fh.write(response.content)
 
             print("For having interactive network, click line below:")
             tmp = "%0d".join(genes)
-            print(f"https://string-db.org/api/tsv/get_link?identifiers={tmp}&species={params['species']}")
+            print(
+                f"https://string-db.org/api/tsv/get_link?identifiers={tmp}&species={params['species']}"
+            )
 
         sleep(1)
 
@@ -3738,20 +4745,21 @@ class WGCNA(GeneExp):
         :rtype: pandas dataframe
         """
 
-        modules = np.unique(self.datExpr.var['moduleColors']).tolist()
+        modules = np.unique(self.datExpr.var["moduleColors"]).tolist()
         if np.all(moduleName not in modules):
             print(f"{WARNING}Module name does not exist in {ENDC}")
             return
 
         datExpr = self.datExpr.copy()
-        datExpr = datExpr[:, datExpr.var['moduleColors'] == moduleName]
-        adj = WGCNA.adjacency(datExpr.to_df(), power=self.power, adjacencyType=self.networkType)
-        adj = pd.DataFrame(adj,
-                           columns=datExpr.to_df().columns,
-                           index=datExpr.to_df().columns)
+        datExpr = datExpr[:, datExpr.var["moduleColors"] == moduleName]
+        adj = WGCNA.adjacency(
+            datExpr.to_df(), power=self.power, adjacencyType=self.networkType
+        )
+        adj = pd.DataFrame(
+            adj, columns=datExpr.to_df().columns, index=datExpr.to_df().columns
+        )
         hub_genes = adj.sum().sort_values(ascending=False)
-        hub_genes = pd.DataFrame(hub_genes,
-                                 columns=["connectivity"])
+        hub_genes = pd.DataFrame(hub_genes, columns=["connectivity"])
 
         hub_genes = pd.concat([hub_genes, datExpr.var], axis=1)
         hub_genes = hub_genes.iloc[:n, :]

--- a/PyWGCNA/wgcna.py
+++ b/PyWGCNA/wgcna.py
@@ -14,7 +14,7 @@ from scipy.stats import t
 from scipy.stats import rankdata
 from statsmodels.formula.api import ols
 from matplotlib import colors as mcolors
-from sklearn.impute import KNNImputer
+from sklearn.impute import KNNImputer 
 from sklearn.preprocessing import scale
 import matplotlib.pyplot as plt
 import pickle
@@ -38,14 +38,14 @@ except ImportError:
         sys.exit("resource or rsrc package is not installed!")
 
 # remove runtime warning (divided by zero)
-np.seterr(divide="ignore", invalid="ignore")
-warnings.simplefilter(action="ignore", category=FutureWarning)
+np.seterr(divide='ignore', invalid='ignore')
+warnings.simplefilter(action='ignore', category=FutureWarning)
 warnings.filterwarnings("ignore")
 
 plt.rcParams["axes.edgecolor"] = "black"
 plt.rcParams["axes.linewidth"] = 1
 plt.rcParams["axes.facecolor"] = "white"
-plt.rcParams["legend.title_fontsize"] = 15
+plt.rcParams['legend.title_fontsize'] = 15
 
 sns.set_style("white")
 
@@ -143,41 +143,18 @@ class WGCNA(GeneExp):
     :type moduleTraitPvalue: pandas dataframe
     """
 
-    def __init__(
-        self,
-        name="WGCNA",
-        TPMcutoff=1,
-        powers=None,
-        RsquaredCut=0.9,
-        MeanCut=100,
-        networkType="signed hybrid",
-        TOMType="signed",
-        minModuleSize=50,
-        naColor="grey",
-        cut=float("inf"),
-        MEDissThres=0.2,
-        species=None,
-        level="gene",
-        anndata=None,
-        geneExp=None,
-        geneExpPath=None,
-        sep=",",
-        geneInfo=None,
-        sampleInfo=None,
-        save=False,
-        outputPath=None,
-        figureType="pdf",
-    ):
-        super().__init__(
-            species=species,
-            level=level,
-            anndata=anndata,
-            geneExp=geneExp,
-            geneExpPath=geneExpPath,
-            sep=sep,
-            geneInfo=geneInfo,
-            sampleInfo=sampleInfo,
-        )
+    def __init__(self, name='WGCNA',
+                 TPMcutoff=1,
+                 powers=None, RsquaredCut=0.9, MeanCut=100,
+                 networkType="signed hybrid", TOMType="signed",
+                 minModuleSize=50, naColor="grey", cut=float('inf'),
+                 MEDissThres=0.2,
+                 species=None, level='gene', anndata=None, geneExp=None,
+                 geneExpPath=None, sep=',', geneInfo=None, sampleInfo=None,
+                 save=False, outputPath=None, figureType='pdf'):
+
+        super().__init__(species=species, level=level, anndata=anndata, geneExp=geneExp,
+                         geneExpPath=geneExpPath, sep=sep, geneInfo=geneInfo, sampleInfo=sampleInfo)
 
         if powers is None:
             powers = list(range(1, 11)) + list(range(11, 21, 2))
@@ -221,11 +198,9 @@ class WGCNA(GeneExp):
 
         if self.save:
             print(f"{OKGREEN}Saving data to be True, checking requirements ...{ENDC}")
-            if not os.path.exists(self.outputPath + "figures/"):
-                print(
-                    f"{WARNING}Figure directory does not exist!\nCreating figure directory!{ENDC}"
-                )
-                os.makedirs(self.outputPath + "figures/")
+            if not os.path.exists(self.outputPath + 'figures/'):
+                print(f"{WARNING}Figure directory does not exist!\nCreating figure directory!{ENDC}")
+                os.makedirs(self.outputPath + 'figures/')
 
         self.figureType = figureType
 
@@ -240,9 +215,7 @@ class WGCNA(GeneExp):
 
         # Prepare and clean data
         # Remove cols with less than 1 TPM
-        self.datExpr = self.datExpr[
-            :, (self.datExpr.to_df() > self.TPMcutoff).any(axis=0)
-        ]
+        self.datExpr = self.datExpr[:, (self.datExpr.to_df() > self.TPMcutoff).any(axis=0)]
 
         # Check that all genes and samples have sufficiently low numbers of missing values.
         goodGenes, goodSamples, allOK = WGCNA.goodSamplesGenes(self.datExpr.to_df().T)
@@ -251,18 +224,14 @@ class WGCNA(GeneExp):
             # Optionally, print the gene and sample names that were removed:
             if np.size(goodGenes) - np.count_nonzero(goodGenes) > 0:
                 print(
-                    f"{OKGREEN} {np.size(goodGenes) - np.count_nonzero(goodGenes)} gene(s) detected as an outlier!{ENDC}"
-                )
+                    f"{OKGREEN} {np.size(goodGenes) - np.count_nonzero(goodGenes)} gene(s) detected as an outlier!{ENDC}")
                 print(
-                    f"{OKGREEN}Removing genes: {', '.join(self.datExpr.var.index[[not goodGene for goodGene in goodGenes]].tolist())}{ENDC}"
-                )
+                    f"{OKGREEN}Removing genes: {', '.join(self.datExpr.var.index[[not goodGene for goodGene in goodGenes]].tolist())}{ENDC}")
             if np.size(goodSamples) - np.count_nonzero(goodSamples) > 0:
                 print(
-                    f"{OKGREEN} {np.size(goodSamples) - np.count_nonzero(goodSamples)} sample(s) detected as an outlier!{ENDC}"
-                )
+                    f"{OKGREEN} {np.size(goodSamples) - np.count_nonzero(goodSamples)} sample(s) detected as an outlier!{ENDC}")
                 print(
-                    f"{OKGREEN}Removing samples: {', '.join(self.datExpr.obs.index[[not goodSample for goodSample in goodSamples]].tolist())}{ENDC}"
-                )
+                    f"{OKGREEN}Removing samples: {', '.join(self.datExpr.obs.index[[not goodSample for goodSample in goodSamples]].tolist())}{ENDC}")
             # Remove the offending genes and samples from the data:
             self.datExpr = self.datExpr[goodSamples, goodGenes]
 
@@ -270,28 +239,18 @@ class WGCNA(GeneExp):
         sampleTree = WGCNA.hclust(pdist(self.datExpr.to_df()), method="average")
 
         if show:
-            plt.figure(
-                figsize=(max(25, round(self.datExpr.X.shape[0] / 20)), 10),
-                facecolor="white",
-            )
-            dendrogram(
-                sampleTree,
-                color_threshold=self.cut,
-                labels=self.datExpr.to_df().index,
-                leaf_rotation=90,
-                leaf_font_size=8,
-            )
-            plt.axhline(y=self.cut, c="grey", lw=1, linestyle="dashed")
-            plt.title("Sample clustering to detect outliers")
-            plt.xlabel("Samples")
-            plt.ylabel("Distances")
+            plt.figure(figsize=(max(25, round(self.datExpr.X.shape[0] / 20)), 10), facecolor='white')
+            dendrogram(sampleTree, color_threshold=self.cut, labels=self.datExpr.to_df().index, leaf_rotation=90,
+                       leaf_font_size=8)
+            plt.axhline(y=self.cut, c='grey', lw=1, linestyle='dashed')
+            plt.title('Sample clustering to detect outliers')
+            plt.xlabel('Samples')
+            plt.ylabel('Distances')
             plt.tight_layout()
             if self.save:
-                plt.savefig(
-                    f"{self.outputPath}figures/"
-                    f"{self.name}_sample_clustering_cleaning.{self.figureType}",
-                    bbox_inches="tight",
-                )
+                plt.savefig(f"{self.outputPath}figures/"\
+                            f"{self.name}_sample_clustering_cleaning.{self.figureType}",
+                            bbox_inches='tight')
 
         # Determine cluster under the line
         clust = WGCNA.cutree(sampleTree, cutHeight=self.cut)
@@ -303,10 +262,7 @@ class WGCNA(GeneExp):
 
         print("\tDone pre-processing..\n")
 
-    def findModules(
-        self,
-        kwargs_function={"cutreeHybrid": {"deepSplit": 2, "pamRespectsDendro": False}},
-    ):
+    def findModules(self, kwargs_function={'cutreeHybrid': {'deepSplit': 2, 'pamRespectsDendro': False}}):
         """
         Clustering genes through original WGCNA pipeline: 1.pick soft threshold 2.calculating adjacency matrix 3.calculating TOM similarity matrix 4.cluster genes base of dissTOM 5.merge similar cluster dynamically
 
@@ -317,83 +273,51 @@ class WGCNA(GeneExp):
 
         # Call the network topology analysis function
         kwargs = dict()
-        if "pickSoftThreshold" in list(kwargs_function.keys()):
-            kwargs = kwargs_function["pickSoftThreshold"]
-        self.power, self.sft = WGCNA.pickSoftThreshold(
-            self.datExpr.to_df(),
-            RsquaredCut=self.RsquaredCut,
-            MeanCut=self.MeanCut,
-            powerVector=self.powers,
-            networkType=self.networkType,
-            **kwargs,
-        )
+        if 'pickSoftThreshold' in list(kwargs_function.keys()):
+            kwargs = kwargs_function['pickSoftThreshold']
+        self.power, self.sft = WGCNA.pickSoftThreshold(self.datExpr.to_df(), RsquaredCut=self.RsquaredCut,
+                                                       MeanCut=self.MeanCut, powerVector=self.powers,
+                                                       networkType=self.networkType, **kwargs)
 
-        fig, ax = plt.subplots(ncols=2, figsize=(10, 5), facecolor="white")
-        ax[0].plot(
-            self.sft["Power"],
-            -1 * np.sign(self.sft["slope"]) * self.sft["SFT.R.sq"],
-            "o",
-        )
+        fig, ax = plt.subplots(ncols=2, figsize=(10, 5), facecolor='white')
+        ax[0].plot(self.sft['Power'], -1 * np.sign(self.sft['slope']) * self.sft['SFT.R.sq'], 'o')
         for i in range(len(self.powers)):
-            ax[0].text(
-                self.sft.loc[i, "Power"],
-                -1 * np.sign(self.sft.loc[i, "slope"]) * self.sft.loc[i, "SFT.R.sq"],
-                str(self.sft.loc[i, "Power"]),
-                ha="center",
-                va="center",
-                color="black",
-                weight="bold",
-            )
-        ax[0].axhline(0.9, color="r")
+            ax[0].text(self.sft.loc[i, 'Power'],
+                       -1 * np.sign(self.sft.loc[i, 'slope']) * self.sft.loc[i, 'SFT.R.sq'],
+                       str(self.sft.loc[i, 'Power']), ha="center", va="center", color='black', weight='bold')
+        ax[0].axhline(0.9, color='r')
         ax[0].set_xlabel("Soft Threshold (power)")
         ax[0].set_ylabel("Scale Free Topology Model Fit,signed R^2")
-        ax[0].title.set_text("Scale independence")
+        ax[0].title.set_text('Scale independence')
 
-        ax[1].plot(self.sft["Power"], self.sft["mean(k)"], "o")
+        ax[1].plot(self.sft['Power'], self.sft['mean(k)'], 'o')
         for i in range(len(self.powers)):
-            ax[1].text(
-                self.sft.loc[i, "Power"],
-                self.sft.loc[i, "mean(k)"],
-                str(self.sft.loc[i, "Power"]),
-                ha="center",
-                va="center",
-                color="r",
-                weight="bold",
-            )
+            ax[1].text(self.sft.loc[i, 'Power'], self.sft.loc[i, 'mean(k)'],
+                       str(self.sft.loc[i, 'Power']), ha="center", va="center", color='r', weight='bold')
         ax[1].set_xlabel("Soft Threshold (power)")
         ax[1].set_ylabel("Mean Connectivity")
-        ax[1].title.set_text("Mean connectivity")
+        ax[1].title.set_text('Mean connectivity')
 
         fig.tight_layout()
         if self.save:
-            fig.savefig(
-                f"{self.outputPath}figures/{self.name}_summary_power.{self.figureType}",
-                bbox_inches="tight",
-            )
+            fig.savefig(f"{self.outputPath}figures/{self.name}_summary_power.{self.figureType}", \
+                        bbox_inches='tight')
 
         # Set Power
         kwargs = dict()
-        if "adjacency" in list(kwargs_function.keys()):
-            kwargs = kwargs_function["adjacency"]
-        self.adjacency = WGCNA.adjacency(
-            self.datExpr.to_df(),
-            power=self.power,
-            adjacencyType=self.networkType,
-            **kwargs,
-        )
-        self.adjacency = pd.DataFrame(
-            self.adjacency,
-            columns=self.datExpr.to_df().columns,
-            index=self.datExpr.to_df().columns,
-        )
+        if 'adjacency' in list(kwargs_function.keys()):
+            kwargs = kwargs_function['adjacency']
+        self.adjacency = WGCNA.adjacency(self.datExpr.to_df(), power=self.power, adjacencyType=self.networkType,
+                                         **kwargs)
+        self.adjacency = pd.DataFrame(self.adjacency,
+                                      columns=self.datExpr.to_df().columns,
+                                      index=self.datExpr.to_df().columns)
 
         # Turn adjacency into topological overlap
         kwargs = dict()
-        if "TOMsimilarity" in list(kwargs_function.keys()):
-            kwargs = kwargs_function["TOMsimilarity"]
-        self.TOM = WGCNA.TOMsimilarity(
-            self.adjacency.to_numpy(), TOMType=self.TOMType, **kwargs
-        )
+        if 'TOMsimilarity' in list(kwargs_function.keys()):
+            kwargs = kwargs_function['TOMsimilarity']
+        self.TOM = WGCNA.TOMsimilarity(self.adjacency.to_numpy(), TOMType=self.TOMType, **kwargs)
         self.TOM.columns = self.datExpr.to_df().columns
         self.TOM.index = self.datExpr.to_df().columns
         dissTOM = 1 - self.TOM
@@ -405,106 +329,76 @@ class WGCNA(GeneExp):
 
         # Module identification using dynamic tree cut
         kwargs = dict()
-        if "cutreeHybrid" in list(kwargs_function.keys()):
-            kwargs = kwargs_function["cutreeHybrid"]
-        dynamicMods = WGCNA.cutreeHybrid(
-            dendro=self.geneTree,
-            distM=dissTOM,
-            minClusterSize=self.minModuleSize,
-            **kwargs,
-        )
+        if 'cutreeHybrid' in list(kwargs_function.keys()):
+            kwargs = kwargs_function['cutreeHybrid']
+        dynamicMods = WGCNA.cutreeHybrid(dendro=self.geneTree, distM=dissTOM, minClusterSize=self.minModuleSize,
+                                         **kwargs)
 
         # Convert numeric labels into colors
         kwargs = dict()
-        if "labels2colors" in list(kwargs_function.keys()):
-            kwargs = kwargs_function["labels2colors"]
-        self.datExpr.var["dynamicColors"] = WGCNA.labels2colors(
-            labels=dynamicMods, **kwargs
-        )
+        if 'labels2colors' in list(kwargs_function.keys()):
+            kwargs = kwargs_function['labels2colors']
+        self.datExpr.var['dynamicColors'] = WGCNA.labels2colors(labels=dynamicMods, **kwargs)
 
         # Calculate eigengenes
         kwargs = dict()
-        if "moduleEigengenes" in list(kwargs_function.keys()):
-            kwargs = kwargs_function["moduleEigengenes"]
-        MEList = WGCNA.moduleEigengenes(
-            expr=self.datExpr.to_df(),
-            colors=self.datExpr.var["dynamicColors"],
-            **kwargs,
-        )
+        if 'moduleEigengenes' in list(kwargs_function.keys()):
+            kwargs = kwargs_function['moduleEigengenes']
+        MEList = WGCNA.moduleEigengenes(expr=self.datExpr.to_df(), colors=self.datExpr.var['dynamicColors'], **kwargs)
 
-        self.MEs = MEList["eigengenes"]
-        if "MEgrey" in self.MEs.columns:
-            self.MEs.drop(["MEgrey"], axis=1, inplace=True)
+        self.MEs = MEList['eigengenes']
+        if 'MEgrey' in self.MEs.columns:
+            self.MEs.drop(['MEgrey'], axis=1, inplace=True)
         # Calculate dissimilarity of module eigengenes
-        MEDiss = pd.DataFrame(
-            1 - np.corrcoef(self.MEs, rowvar=False),
-            index=self.MEs.columns,
-            columns=self.MEs.columns,
-        )
+        MEDiss = pd.DataFrame(1 - np.corrcoef(self.MEs, rowvar=False), index=self.MEs.columns, columns=self.MEs.columns)
         if MEDiss.shape != (1, 1):
             # Cluster module eigengenes
             a = squareform(MEDiss, checks=False)
 
             METree = WGCNA.hclust(a, method="average")
 
-            plt.figure(
-                figsize=(max(20, round(MEDiss.shape[1] / 20)), 10), facecolor="white"
-            )
-            dendrogram(
-                METree,
-                color_threshold=self.MEDissThres,
-                labels=MEDiss.columns,
-                leaf_rotation=90,
-                leaf_font_size=8,
-            )
-            plt.axhline(y=self.MEDissThres, c="grey", lw=1, linestyle="dashed")
-            plt.title("Clustering of module eigengenes")
-            plt.xlabel("")
-            plt.ylabel("")
+            plt.figure(figsize=(max(20, round(MEDiss.shape[1] / 20)), 10), facecolor='white')
+            dendrogram(METree, color_threshold=self.MEDissThres, labels=MEDiss.columns, leaf_rotation=90,
+                       leaf_font_size=8)
+            plt.axhline(y=self.MEDissThres, c='grey', lw=1, linestyle='dashed')
+            plt.title('Clustering of module eigengenes')
+            plt.xlabel('')
+            plt.ylabel('')
             plt.tight_layout()
             if self.save:
-                plt.savefig(
-                    f"{self.outputPath}figures/{self.name}_eigenesgenes.{self.figureType}",
-                    bbox_inches="tight",
-                )
+                plt.savefig(f"{self.outputPath}figures/{self.name}_eigenesgenes.{self.figureType}", \
+                            bbox_inches='tight')
 
             # Call an automatic merging function
             kwargs = dict()
-            if "mergeCloseModules" in list(kwargs_function.keys()):
-                kwargs = kwargs_function["mergeCloseModules"]
-            merge = WGCNA.mergeCloseModules(
-                self.datExpr.to_df(),
-                self.datExpr.var["dynamicColors"],
-                cutHeight=self.MEDissThres,
-                **kwargs,
-            )
+            if 'mergeCloseModules' in list(kwargs_function.keys()):
+                kwargs = kwargs_function['mergeCloseModules']
+            merge = WGCNA.mergeCloseModules(self.datExpr.to_df(), self.datExpr.var['dynamicColors'],
+                                            cutHeight=self.MEDissThres, **kwargs)
             # The merged module colors; Rename to moduleColors
-            self.datExpr.var["moduleColors"] = merge["colors"]
+            self.datExpr.var['moduleColors'] = merge['colors']
         else:
-            self.datExpr.var["moduleColors"] = ["black"] * self.datExpr.shape[1]
+            self.datExpr.var['moduleColors'] = ["black"] * self.datExpr.shape[1]
 
         # Construct numerical labels corresponding to the colors
-        colorOrder = np.unique(self.datExpr.var["moduleColors"]).tolist()
-        self.datExpr.var["moduleLabels"] = [
-            colorOrder.index(x) if x in colorOrder else None
-            for x in self.datExpr.var["moduleColors"]
-        ]
+        colorOrder = np.unique(self.datExpr.var['moduleColors']).tolist()
+        self.datExpr.var['moduleLabels'] = [colorOrder.index(x) if x in colorOrder else None for x in
+                                            self.datExpr.var['moduleColors']]
         # Eigengenes of the new merged modules:
-        self.MEs = merge["newMEs"]
+        self.MEs = merge['newMEs']
 
         # Recalculate MEs with color labels
         kwargs = dict()
-        if "moduleEigengenes" in list(kwargs_function.keys()):
-            kwargs = kwargs_function["moduleEigengenes"]
-        self.datME = WGCNA.moduleEigengenes(
-            self.datExpr.to_df(), self.datExpr.var["moduleColors"], **kwargs
-        )["eigengenes"]
-        if "MEgrey" in self.datME.columns:
-            self.datME.drop(["MEgrey"], axis=1, inplace=True)
+        if 'moduleEigengenes' in list(kwargs_function.keys()):
+            kwargs = kwargs_function['moduleEigengenes']
+        self.datME = WGCNA.moduleEigengenes(self.datExpr.to_df(), self.datExpr.var['moduleColors'], **kwargs)[
+            'eigengenes']
+        if 'MEgrey' in self.datME.columns:
+            self.datME.drop(['MEgrey'], axis=1, inplace=True)
 
         kwargs = dict()
-        if "orderMEs" in list(kwargs_function.keys()):
-            kwargs = kwargs_function["orderMEs"]
+        if 'orderMEs' in list(kwargs_function.keys()):
+            kwargs = kwargs_function['orderMEs']
         self.MEs = WGCNA.orderMEs(self.datME, **kwargs)
 
         print("\tDone running WGCNA..\n")
@@ -519,9 +413,7 @@ class WGCNA(GeneExp):
 
         return self
 
-    def analyseWGCNA(
-        self, order=None, geneList=None, show=True, alternative="two-sided"
-    ):
+    def analyseWGCNA(self, order=None, geneList=None, show=True, alternative='two-sided'):
         """
         Analysing results: 1.calculating module trait relationship 2.plotting module heatmap eigengene 3.finding GO term for each module
 
@@ -538,24 +430,18 @@ class WGCNA(GeneExp):
 
         print(f"{OKCYAN}Calculating module trait relationship ...{ENDC}")
 
-        self.module_trait_relationships_heatmap(
-            metaData=self.datExpr.obs.columns.tolist(),
-            alternative=alternative,
-            show=show,
-            file_name=f"{self.name}_module-traitRelationships",
-        )
+        self.module_trait_relationships_heatmap(metaData=self.datExpr.obs.columns.tolist(),
+                                                alternative=alternative,
+                                                show=show,
+                                                file_name=f'{self.name}_module-traitRelationships')
         print("\tDone..\n")
 
-        print(
-            f"{OKCYAN}Adding (signed) eigengene-based connectivity (module membership) ...{ENDC}"
-        )
+        print(f"{OKCYAN}Adding (signed) eigengene-based connectivity (module membership) ...{ENDC}")
         self.CalculateSignedKME()
         print("\tDone..\n")
 
         if geneList is not None:
-            print(
-                f"{OKCYAN}Updating gene information based on given gene list ...{ENDC}"
-            )
+            print(f"{OKCYAN}Updating gene information based on given gene list ...{ENDC}")
             self.updateGeneInfo(geneInfo=geneList)
             print("\tDone..\n")
 
@@ -578,24 +464,21 @@ class WGCNA(GeneExp):
             print(f"{OKCYAN}plotting module barplot eigengene...{ENDC}")
             if self.datExpr.obs.shape[1] == 0:
                 print(
-                    f"{WARNING}There is not any sample information in given object! Skip running barplotModuleEigenGene() function.{ENDC}"
-                )
+                    f"{WARNING}There is not any sample information in given object! Skip running barplotModuleEigenGene() function.{ENDC}")
             else:
                 for module in modules:
-                    self.barplotModuleEigenGene(
-                        module, metadata, colorBar=metadata[-1], show=show
-                    )
+                    self.barplotModuleEigenGene(module, metadata, colorBar=metadata[-1], show=show)
                 print("\tDone..\n")
 
         if self.save:
             print(f"{OKCYAN}doing Enrichr GO analysis for each module...{ENDC}")
-            if "gene_name" not in self.datExpr.var.columns:
+            if 'gene_name' not in self.datExpr.var.columns:
                 print(
-                    f"{WARNING}\tgene name didn't found in gene information!\n\t Go term analysis can not be done{ENDC}"
-                )
+                    f"{WARNING}\tgene name didn't found in gene information!\n\t Go term analysis can not be done{ENDC}")
             else:
                 for module in modules:
-                    self.functional_enrichment_analysis(type="GO", moduleName=module)
+                    self.functional_enrichment_analysis(type="GO",
+                                                        moduleName=module)
             print("\tDone..\n")
 
     @staticmethod
@@ -640,17 +523,13 @@ class WGCNA(GeneExp):
 
         weights = np.asmatrix(weights)
         if expr.shape != weights.shape:
-            sys.exit(
-                "When 'weights' are given, they must have the same dimensions as 'expr'."
-            )
+            sys.exit("When 'weights' are given, they must have the same dimensions as 'expr'.")
         if (weights < 0).any():
             sys.exit("Found negative weights. All weights must be non-negative.")
 
         nf = np.isinf(weights)
         if any(nf):
-            print(
-                f"{WARNING}Found non-finite weights. The corresponding data points will be removed.{ENDC}"
-            )
+            print(f"{WARNING}Found non-finite weights. The corresponding data points will be removed.{ENDC}")
             weights[nf] = None
 
         if scaleByMax:
@@ -662,15 +541,8 @@ class WGCNA(GeneExp):
 
     # Check that all genes and samples have sufficiently low numbers of missing values.
     @staticmethod
-    def goodSamplesGenes(
-        datExpr,
-        weights=None,
-        minFraction=1 / 2,
-        minNSamples=4,
-        minNGenes=4,
-        tol=None,
-        minRelativeWeight=0.1,
-    ):
+    def goodSamplesGenes(datExpr, weights=None, minFraction=1 / 2, minNSamples=4, minNGenes=4, tol=None,
+                         minRelativeWeight=0.1):
         """
         Checks data for missing entries, entries with weights below a threshold, and zero-variance genes. If necessary, the filtering is iterated.
 
@@ -698,56 +570,29 @@ class WGCNA(GeneExp):
         nBadSamples = 0
         changed = True
         iter = 1
-        print(
-            "\tDetecting genes and samples with too many missing values...", flush=True
-        )
+        print("\tDetecting genes and samples with too many missing values...", flush=True)
         while changed:
-            goodGenes = WGCNA.goodGenesFun(
-                datExpr,
-                weights,
-                goodSamples,
-                goodGenes,
-                minFraction=minFraction,
-                minNSamples=minNSamples,
-                minNGenes=minNGenes,
-                minRelativeWeight=minRelativeWeight,
-                tol=tol,
-            )
-            goodSamples = WGCNA.goodSamplesFun(
-                datExpr,
-                weights,
-                goodSamples,
-                goodGenes,
-                minFraction=minFraction,
-                minNSamples=minNSamples,
-                minNGenes=minNGenes,
-                minRelativeWeight=minRelativeWeight,
-            )
-            changed = np.logical_or(
-                (np.logical_not(goodGenes).sum() > nBadGenes),
-                (np.logical_not(goodSamples).sum() > nBadSamples),
-            )
+            goodGenes = WGCNA.goodGenesFun(datExpr, weights, goodSamples, goodGenes, minFraction=minFraction,
+                                           minNSamples=minNSamples, minNGenes=minNGenes,
+                                           minRelativeWeight=minRelativeWeight,
+                                           tol=tol)
+            goodSamples = WGCNA.goodSamplesFun(datExpr, weights, goodSamples, goodGenes, minFraction=minFraction,
+                                               minNSamples=minNSamples, minNGenes=minNGenes,
+                                               minRelativeWeight=minRelativeWeight)
+            changed = np.logical_or((np.logical_not(goodGenes).sum() > nBadGenes),
+                                    (np.logical_not(goodSamples).sum() > nBadSamples))
             nBadGenes = np.logical_not(goodGenes).sum()
             nBadSamples = np.logical_not(goodSamples).sum()
             iter = iter + 1
 
-        allOK = nBadGenes + nBadSamples == 0
+        allOK = (nBadGenes + nBadSamples == 0)
 
         return goodGenes, goodSamples, allOK
 
     # Filter genes with too many missing entries
     @staticmethod
-    def goodGenesFun(
-        datExpr,
-        weights=None,
-        useSamples=None,
-        useGenes=None,
-        minFraction=1 / 2,
-        minNSamples=4,
-        minNGenes=4,
-        tol=None,
-        minRelativeWeight=0.1,
-    ):
+    def goodGenesFun(datExpr, weights=None, useSamples=None, useGenes=None, minFraction=1 / 2,
+                     minNSamples=4, minNGenes=4, tol=None, minRelativeWeight=0.1):
         """
         Check data for missing entries and returns a list of genes that have non-zero variance
 
@@ -773,9 +618,7 @@ class WGCNA(GeneExp):
         :return: A logical list with one entry per gene that is TRUE if the gene is considered good and FALSE otherwise. Note that all genes excluded by useGenes are automatically assigned FALSE.
         :rtype: list of bool
         """
-        if not datExpr.apply(
-            lambda s: pd.to_numeric(s, errors="coerce").notnull().all()
-        ).all():
+        if not datExpr.apply(lambda s: pd.to_numeric(s, errors='coerce').notnull().all()).all():
             sys.exit("datExpr must contain numeric data.")
 
         weights = WGCNA.checkAndScaleWeights(weights, datExpr, scaleByMax=True)
@@ -788,23 +631,17 @@ class WGCNA(GeneExp):
             useSamples = np.repeat(True, datExpr.shape[1])
 
         if len(useGenes) != datExpr.shape[0]:
-            sys.exit(
-                "Length of nGenes is not compatible with number of columns in datExpr."
-            )
+            sys.exit("Length of nGenes is not compatible with number of columns in datExpr.")
         if len(useSamples) != datExpr.shape[1]:
-            sys.exit(
-                "Length of nSamples is not compatible with number of rows in datExpr."
-            )
+            sys.exit("Length of nSamples is not compatible with number of rows in datExpr.")
 
         nSamples = sum(useSamples)
         nGenes = sum(useGenes)
         if weights is None:
             nPresent = datExpr.loc[useGenes, useSamples].notna().sum(axis=1)
         else:
-            nPresent = (
-                datExpr.loc[useGenes, useSamples].notna()
-                and weights.loc[useGenes, useSamples] > minRelativeWeight
-            ).sum(axis=1)
+            nPresent = (datExpr.loc[useGenes, useSamples].notna() and
+                        weights.loc[useGenes, useSamples] > minRelativeWeight).sum(axis=1)
 
         gg = useGenes.copy()
         if len(useGenes) != len(nPresent):
@@ -829,37 +666,21 @@ class WGCNA(GeneExp):
 
         var[pd.isnull(var)] = 0
         nNAsGenes = datExpr.loc[gg, useSamples].isna().sum(axis=1)
-        gg[gg] = np.logical_and(
-            np.logical_and(nNAsGenes < (1 - minFraction) * nSamples, var > tol**2),
-            nSamples - nNAsGenes >= minNSamples,
-        )
+        gg[gg] = np.logical_and(np.logical_and(nNAsGenes < (1 - minFraction) * nSamples, var > tol ** 2),
+                                nSamples - nNAsGenes >= minNSamples)
 
         if sum(gg) < minNGenes:
-            sys.exit(
-                "Too few genes with valid expression levels in the required number of samples."
-            )
+            sys.exit("Too few genes with valid expression levels in the required number of samples.")
         if nGenes - sum(gg) > 0:
-            print(
-                "\n\n  ..Excluding",
-                nGenes - sum(gg),
-                "genes from the calculation due to too many missing samples or zero variance.\n\n",
-                flush=True,
-            )
+            print("\n\n  ..Excluding", nGenes - sum(gg),
+                  "genes from the calculation due to too many missing samples or zero variance.\n\n", flush=True)
 
         return gg
 
     # Filter samples with too many missing entries
     @staticmethod
-    def goodSamplesFun(
-        datExpr,
-        weights=None,
-        useSamples=None,
-        useGenes=None,
-        minFraction=1 / 2,
-        minNSamples=4,
-        minNGenes=4,
-        minRelativeWeight=0.1,
-    ):
+    def goodSamplesFun(datExpr, weights=None, useSamples=None, useGenes=None, minFraction=1 / 2,
+                       minNSamples=4, minNGenes=4, minRelativeWeight=0.1):
         """
         Check data for missing entries and returns a list of samples that have non-zero variance
 
@@ -890,14 +711,10 @@ class WGCNA(GeneExp):
             useSamples = np.repeat(True, datExpr.shape[1])
 
         if len(useGenes) != datExpr.shape[0]:
-            sys.exit(
-                "Length of nGenes is not compatible with number of columns in datExpr."
-            )
+            sys.exit("Length of nGenes is not compatible with number of columns in datExpr.")
 
         if len(useSamples) != datExpr.shape[1]:
-            sys.exit(
-                "Length of nSamples is not compatible with number of rows in datExpr."
-            )
+            sys.exit("Length of nSamples is not compatible with number of rows in datExpr.")
 
         weights = WGCNA.checkAndScaleWeights(weights, datExpr, scaleByMax=True)
         nSamples = sum(useSamples)
@@ -905,34 +722,21 @@ class WGCNA(GeneExp):
         if weights is None:
             nNAsSamples = np.sum((datExpr.loc[useGenes, useSamples]).isnull(), axis=0)
         else:
-            nNAsSamples = np.sum(
-                np.logical_or(
-                    datExpr[useGenes, useSamples],
-                    WGCNA.replaceMissing(
-                        weights[useGenes, useSamples] < minRelativeWeight, True
-                    ),
-                ).isnull(),
-                axis=0,
-            )
+            nNAsSamples = np.sum(np.logical_or(datExpr[useGenes, useSamples],
+                                               WGCNA.replaceMissing(weights[useGenes, useSamples] < minRelativeWeight,
+                                                                    True))
+                                 .isnull(), axis=0)
 
         goodSamples = useSamples
-        goodSamples[useSamples] = np.logical_and(
-            (nNAsSamples < (1 - minFraction) * nGenes),
-            (nGenes - nNAsSamples >= minNGenes),
-        )
+        goodSamples[useSamples] = np.logical_and((nNAsSamples < (1 - minFraction) * nGenes),
+                                                 (nGenes - nNAsSamples >= minNGenes))
 
         if sum(goodSamples) < minNSamples:
-            sys.exit(
-                "Too few samples with valid expression levels for the required number of genes."
-            )
+            sys.exit("Too few samples with valid expression levels for the required number of genes.")
 
         if nSamples - sum(goodSamples) > 0:
-            print(
-                "  ..Excluding",
-                nSamples - sum(goodSamples),
-                "samples from the calculation due to too many missing genes.",
-                flush=True,
-            )
+            print("  ..Excluding", nSamples - sum(goodSamples),
+                  "samples from the calculation due to too many missing genes.", flush=True)
 
         return goodSamples
 
@@ -981,20 +785,9 @@ class WGCNA(GeneExp):
 
     # Call the network topology analysis function
     @staticmethod
-    def pickSoftThreshold(
-        data,
-        dataIsExpr=True,
-        weights=None,
-        RsquaredCut=0.9,
-        MeanCut=100,
-        powerVector=None,
-        nBreaks=10,
-        blockSize=None,
-        corOptions=None,
-        networkType="unsigned",
-        moreNetworkConcepts=False,
-        gcInterval=None,
-    ):
+    def pickSoftThreshold(data, dataIsExpr=True, weights=None, RsquaredCut=0.9, MeanCut=100, powerVector=None,
+                          nBreaks=10, blockSize=None, corOptions=None, networkType="unsigned",
+                          moreNetworkConcepts=False, gcInterval=None):
         """
         Analysis of scale free topology for multiple soft thresholding powers.
 
@@ -1031,20 +824,14 @@ class WGCNA(GeneExp):
         powerVector = np.sort(powerVector)
         intType = networkTypes.index(networkType)
         if intType is None:
-            sys.exit(
-                ("Unrecognized 'networkType'. Recognized values are", str(networkTypes))
-            )
+            sys.exit(("Unrecognized 'networkType'. Recognized values are", str(networkTypes)))
 
         nGenes = data.shape[1]
         if nGenes < 3:
-            sys.exit(
-                "The input data data contain fewer than 3 rows (nodes).\n"
-                "This would result in a trivial correlation network."
-            )
+            sys.exit("The input data data contain fewer than 3 rows (nodes).\n"
+                     "This would result in a trivial correlation network.")
 
-        print(
-            f"{OKCYAN}pickSoftThreshold: calculating connectivity for given powers...{ENDC}"
-        )
+        print(f"{OKCYAN}pickSoftThreshold: calculating connectivity for given powers...{ENDC}")
 
         if not dataIsExpr:
             WGCNA.checkSimilarity(data)
@@ -1052,33 +839,19 @@ class WGCNA(GeneExp):
                 data = np.where(np.diag(data), 1)
 
         if blockSize is None:
-            blockSize = WGCNA.calBlockSize(
-                nGenes, rectangularBlocks=True, maxMemoryAllocation=2**30
-            )
+            blockSize = WGCNA.calBlockSize(nGenes, rectangularBlocks=True, maxMemoryAllocation=2 ** 30)
             print("will use block size ", blockSize, flush=True)
 
         if gcInterval is None or len(gcInterval) == 0:
             gcInterval = 4 * blockSize
 
-        colname1 = [
-            "Power",
-            "SFT.R.sq",
-            "slope",
-            "truncated R.sq",
-            "mean(k)",
-            "median(k)",
-            "max(k)",
-        ]
+        colname1 = ["Power", "SFT.R.sq", "slope", "truncated R.sq", "mean(k)", "median(k)", "max(k)"]
 
         if moreNetworkConcepts:
             colname1 = colname1.append(["Density", "Centralization", "Heterogeneity"])
 
-        datout = pd.DataFrame(
-            np.full((len(powerVector), len(colname1)), 666),
-            columns=colname1,
-            dtype=object,
-        )
-        datout["Power"] = powerVector
+        datout = pd.DataFrame(np.full((len(powerVector), len(colname1)), 666), columns=colname1, dtype=object)
+        datout['Power'] = powerVector
 
         datk = np.zeros((nGenes, len(powerVector)))
         nPowers = len(powerVector)
@@ -1086,20 +859,16 @@ class WGCNA(GeneExp):
         lastGC = 0
         if corOptions is None:
             corOptions = pd.DataFrame()
-            corOptions["x"] = [data]
+            corOptions['x'] = [data]
         else:
-            corOptions["x"] = [data]
+            corOptions['x'] = [data]
 
         if weights is not None:
             if not dataIsExpr:
-                sys.exit(
-                    "Weights can only be used when 'data' represents expression data ('dataIsExpr' must be TRUE)."
-                )
+                sys.exit("Weights can only be used when 'data' represents expression data ('dataIsExpr' must be TRUE).")
             if data.shape != weights.shape:
-                sys.exit(
-                    "When 'weights' are given, dimensions of 'data' and 'weights' must be the same."
-                )
-            corOptions["weights.x"] = weights
+                sys.exit("When 'weights' are given, dimensions of 'data' and 'weights' must be the same.")
+            corOptions['weights.x'] = weights
 
         while startG < nGenes:
             endG = min(startG + blockSize, nGenes)
@@ -1107,11 +876,11 @@ class WGCNA(GeneExp):
             useGenes = list(range(startG, endG))
             nGenes1 = len(useGenes)
             if dataIsExpr:
-                corOptions["y"] = [data.iloc[:, useGenes]]
+                corOptions['y'] = [data.iloc[:, useGenes]]
                 if weights is not None:
-                    corOptions["weights.y"] = [weights.iloc[:, useGenes]]
+                    corOptions['weights.y'] = [weights.iloc[:, useGenes]]
                 corx = np.corrcoef(corOptions.x[0], corOptions.y[0], rowvar=False)
-                corx = corx[0 : corOptions.x[0].shape[1], useGenes]
+                corx = corx[0:corOptions.x[0].shape[1], useGenes]
                 if intType == 0:
                     corx = abs(corx)
                 elif intType == 1:
@@ -1121,8 +890,7 @@ class WGCNA(GeneExp):
 
                 if np.count_nonzero(np.isnan(corx)) != 0:
                     print(
-                        f"{WARNING}Some correlations are NA in block {str(startG)} : {str(endG)}.{ENDC}"
-                    )
+                        f"{WARNING}Some correlations are NA in block {str(startG)} : {str(endG)}.{ENDC}")
             else:
                 corx = data.iloc[:, useGenes].to_numpy()
 
@@ -1136,7 +904,7 @@ class WGCNA(GeneExp):
             uniquePowerSteps = np.unique(powerSteps)
 
             def func(power):
-                return corx**power
+                return corx ** power
 
             corxPowers = pd.DataFrame()
             for p in uniquePowerSteps:
@@ -1156,45 +924,33 @@ class WGCNA(GeneExp):
         for i in range(len(powerVector)):
             khelp = datk[:, i]
             SFT1 = WGCNA.scaleFreeFitIndex(k=khelp, nBreaks=nBreaks)
-            datout.loc[i, "SFT.R.sq"] = SFT1.loc[0, "Rsquared.SFT"]
-            datout.loc[i, "slope"] = SFT1.loc[0, "slope.SFT"]
-            datout.loc[i, "truncated R.sq"] = SFT1.loc[
-                0, "truncatedExponentialAdjRsquared"
-            ]
-            datout.loc[i, "mean(k)"] = statistics.mean(khelp)
-            datout.loc[i, "median(k)"] = statistics.median(khelp)
-            datout.loc[i, "max(k)"] = max(khelp)
+            datout.loc[i, 'SFT.R.sq'] = SFT1.loc[0, 'Rsquared.SFT']
+            datout.loc[i, 'slope'] = SFT1.loc[0, 'slope.SFT']
+            datout.loc[i, 'truncated R.sq'] = SFT1.loc[0, 'truncatedExponentialAdjRsquared']
+            datout.loc[i, 'mean(k)'] = statistics.mean(khelp)
+            datout.loc[i, 'median(k)'] = statistics.median(khelp)
+            datout.loc[i, 'max(k)'] = max(khelp)
 
             if moreNetworkConcepts:
                 Density = sum(khelp) / (nGenes * (nGenes - 1))
-                datout.loc[i, "Density"] = Density
-                Centralization = (
-                    nGenes
-                    * (max(khelp) - statistics.mean(khelp))
-                    / ((nGenes - 1) * (nGenes - 2))
-                )
-                datout.loc[i, "Centralization"] = Centralization
+                datout.loc[i, 'Density'] = Density
+                Centralization = nGenes * (max(khelp) - statistics.mean(khelp)) / ((nGenes - 1) * (nGenes - 2))
+                datout.loc[i, 'Centralization'] = Centralization
                 Heterogeneity = np.sqrt(nGenes * sum(khelp ^ 2) / sum(khelp) ^ 2 - 1)
-                datout.loc[i, "Heterogeneity"] = Heterogeneity
+                datout.loc[i, 'Heterogeneity'] = Heterogeneity
 
         print(datout)
 
         # detect threshold more than 0.9 by default
-        ind = np.logical_and(
-            datout["SFT.R.sq"] > RsquaredCut, datout["mean(k)"] <= MeanCut
-        )
+        ind = np.logical_and(datout['SFT.R.sq'] > RsquaredCut, datout['mean(k)'] <= MeanCut)
         if np.sum(ind) > 0:
             powerEstimate = np.min(powerVector[ind])
-            print(
-                f"{OKGREEN}Selected power to have scale free network is {str(powerEstimate)}.{ENDC}"
-            )
+            print(f"{OKGREEN}Selected power to have scale free network is {str(powerEstimate)}.{ENDC}")
         else:
-            ind = np.argsort(datout["SFT.R.sq"]).tolist()
+            ind = np.argsort(datout['SFT.R.sq']).tolist()
             powerEstimate = powerVector[ind[-1]]
-            print(
-                f"{OKGREEN}No power detected to have scale free network!\nFound the best given power which is "
-                f"{str(powerEstimate)}.{ENDC}"
-            )
+            print(f"{OKGREEN}No power detected to have scale free network!\nFound the best given power which is "
+                  f"{str(powerEstimate)}.{ENDC}")
 
         return powerEstimate, datout
 
@@ -1229,9 +985,7 @@ class WGCNA(GeneExp):
             sys.exit(f"some entries are not between {min} and {max}.")
 
     @staticmethod
-    def calBlockSize(
-        matrixSize, rectangularBlocks=True, maxMemoryAllocation=None, overheadFactor=3
-    ):
+    def calBlockSize(matrixSize, rectangularBlocks=True, maxMemoryAllocation=None, overheadFactor=3):
         """
         find suitable block size for calculating soft power threshold
         """
@@ -1260,51 +1014,38 @@ class WGCNA(GeneExp):
         :param nBreaks: (default = 10)
         :type nBreaks: int
         """
-        df = pd.DataFrame({"data": k})
-        df["discretized_k"] = pd.cut(df["data"], nBreaks)
-        dk = df.groupby("discretized_k").mean()  # tapply(k, discretized_k, mean)
+        df = pd.DataFrame({'data': k})
+        df['discretized_k'] = pd.cut(df['data'], nBreaks)
+        dk = df.groupby('discretized_k').mean()  # tapply(k, discretized_k, mean)
         dk = pd.DataFrame(dk.reset_index())
-        dk.columns = ["discretized_k", "dk"]
-        p_dk = df["discretized_k"].value_counts() / len(
-            k
-        )  # as.vector(tapply(k, discretized.k, length)/length(k))
+        dk.columns = ['discretized_k', 'dk']
+        p_dk = df['discretized_k'].value_counts() / len(k)  # as.vector(tapply(k, discretized.k, length)/length(k))
         p_dk = pd.DataFrame(p_dk.reset_index())
-        p_dk.columns = ["discretized_k", "p_dk"]
+        p_dk.columns = ['discretized_k', 'p_dk']
         breaks1 = np.linspace(start=min(k), stop=max(k), num=nBreaks + 1)
-        y, edges = np.histogram(df["data"], bins=breaks1)
+        y, edges = np.histogram(df['data'], bins=breaks1)
         dk2 = 0.5 * (edges[1:] + edges[:-1])
-        df = pd.merge(dk, p_dk, on="discretized_k")
-        if df["dk"].isnull().values.any():
-            df.loc[df["dk"].isnull().values, "dk"] = dk2[df["dk"].isnull().values]
-        if np.any(df["dk"] == 0):
-            df.loc[df["dk"] == 0, "dk"] = dk2[df["dk"] == 0]
-        if df["p_dk"].isnull().values.any():
-            df.loc[df["p_dk"].isnull().values, "p_dk"] = 0
-        df["log_dk"] = np.log10(df["dk"])
-        df["log_p_dk"] = np.log10(df["p_dk"] + 1e-09)
-        df["log_p_dk_10"] = np.power(10, df["log_dk"])
+        df = pd.merge(dk, p_dk, on='discretized_k')
+        if df['dk'].isnull().values.any():
+            df.loc[df['dk'].isnull().values, 'dk'] = dk2[df['dk'].isnull().values]
+        if np.any(df['dk'] == 0):
+            df.loc[df['dk'] == 0, 'dk'] = dk2[df['dk'] == 0]
+        if df['p_dk'].isnull().values.any():
+            df.loc[df['p_dk'].isnull().values, 'p_dk'] = 0
+        df['log_dk'] = np.log10(df['dk'])
+        df['log_p_dk'] = np.log10(df['p_dk'] + 1e-09)
+        df['log_p_dk_10'] = np.power(10, df['log_dk'])
 
-        model1 = ols(formula="log_p_dk ~ log_dk", data=df).fit()
-        model2 = ols(formula="log_p_dk ~ log_dk + log_p_dk_10", data=df).fit()
-        dfout = pd.DataFrame(
-            {
-                "Rsquared.SFT": [model1.rsquared],
-                "slope.SFT": [model1.params.values[1]],
-                "truncatedExponentialAdjRsquared": [model2.rsquared_adj],
-            }
-        )
+        model1 = ols(formula='log_p_dk ~ log_dk', data=df).fit()
+        model2 = ols(formula='log_p_dk ~ log_dk + log_p_dk_10', data=df).fit()
+        dfout = pd.DataFrame({'Rsquared.SFT': [model1.rsquared],
+                              'slope.SFT': [model1.params.values[1]],
+                              'truncatedExponentialAdjRsquared': [model2.rsquared_adj]})
         return dfout
 
     @staticmethod
-    def adjacency(
-        datExpr,
-        selectCols=None,
-        adjacencyType="unsigned",
-        power=6,
-        corOptions=pd.DataFrame(),
-        weights=None,
-        weightArgNames=None,
-    ):
+    def adjacency(datExpr, selectCols=None, adjacencyType="unsigned", power=6, corOptions=pd.DataFrame(), weights=None,
+                  weightArgNames=None):
         """
         Calculates (correlation or distance) network adjacency from given expression data or from a similarity
 
@@ -1331,30 +1072,21 @@ class WGCNA(GeneExp):
             weightArgNames = ["weights.x", "weights.y"]
         intType = adjacencyTypes.index(adjacencyType)
         if intType is None:
-            sys.exit(
-                ("Unrecognized 'type'. Recognized values are", str(adjacencyTypes))
-            )
+            sys.exit(("Unrecognized 'type'. Recognized values are", str(adjacencyTypes)))
         weights = WGCNA.checkAndScaleWeights(weights, datExpr, scaleByMax=False)
         if weights is not None:
             if selectCols is None:
                 if isinstance(corOptions, pd.DataFrame):
-                    weightOpt = pd.DataFrame({"weights.x": weights})
+                    weightOpt = pd.DataFrame({'weights.x': weights})
                     weightOpt.index = weightArgNames[0]
                 else:
                     weightOpt = weightArgNames[0] + " = weights"
             else:
                 if isinstance(corOptions, pd.DataFrame):
-                    weightOpt = pd.DataFrame(
-                        {"weights.x": weights, "weights.y": weights[:, selectCols]}
-                    )
+                    weightOpt = pd.DataFrame({'weights.x': weights, 'weights.y': weights[:, selectCols]})
                     weightOpt.index = weightArgNames[0:2]
                 else:
-                    weightOpt = (
-                        weightArgNames[1]
-                        + " = weights, "
-                        + weightArgNames[2]
-                        + " = weights[, selectCols]"
-                    )
+                    weightOpt = weightArgNames[1] + " = weights, " + weightArgNames[2] + " = weights[, selectCols]"
         else:
             if isinstance(corOptions, pd.DataFrame):
                 weightOpt = pd.DataFrame()
@@ -1363,12 +1095,9 @@ class WGCNA(GeneExp):
 
         if selectCols is None:
             cor_mat = np.corrcoef(
-                datExpr.T
-            )  # cor_mat = do.call(corFnc.fnc, c(list(x = datExpr), weightOpt, corOptions))
+                datExpr.T)  # cor_mat = do.call(corFnc.fnc, c(list(x = datExpr), weightOpt, corOptions))
         else:
-            cor_mat = np.corrcoef(
-                x=datExpr, y=datExpr[:, selectCols]
-            )  # , weightOpt, corOptions)
+            cor_mat = np.corrcoef(x=datExpr, y=datExpr[:, selectCols])  # , weightOpt, corOptions)
 
         if intType == 0:
             cor_mat = abs(cor_mat)
@@ -1379,7 +1108,7 @@ class WGCNA(GeneExp):
 
         print("\tDone..\n")
 
-        return cor_mat**power
+        return cor_mat ** power
 
     @staticmethod
     def checkAdjMat(adjMat, min=0, max=1):
@@ -1447,9 +1176,7 @@ class WGCNA(GeneExp):
             sys.exit(f"Invalid 'TOMType'. Recognized values are {', '.join(TOMTypes)}")
         TOMDenomC = TOMDenoms.index(TOMDenom)
         if TOMDenomC is None:
-            sys.exit(
-                f"Invalid 'TOMDenom'. Recognized values are {', '.join(TOMDenoms)}"
-            )
+            sys.exit(f"Invalid 'TOMDenom'. Recognized values are {', '.join(TOMDenoms)}")
 
         min = 0
         if TOMTypeC == 1:
@@ -1488,6 +1215,7 @@ class WGCNA(GeneExp):
 
     @staticmethod
     def get_heights(Z):
+
         clusternode = to_tree(Z, True)
         height = np.array([c.dist for c in clusternode[1] if c.is_leaf() is not True])
 
@@ -1509,30 +1237,14 @@ class WGCNA(GeneExp):
         return merges
 
     @staticmethod
-    def cutreeHybrid(
-        dendro,
-        distM,
-        cutHeight=None,
-        minClusterSize=20,
-        deepSplit=1,
-        maxCoreScatter=None,
-        minGap=None,
-        maxAbsCoreScatter=None,
-        minAbsGap=None,
-        minSplitHeight=None,
-        minAbsSplitHeight=None,
-        externalBranchSplitFnc=None,
-        nExternalSplits=0,
-        minExternalSplit=None,
-        externalSplitOptions=pd.DataFrame(),
-        externalSplitFncNeedsDistance=None,
-        assumeSimpleExternalSpecification=True,
-        pamStage=True,
-        pamRespectsDendro=True,
-        useMedoids=False,
-        maxPamDist=None,
-        respectSmallClusters=True,
-    ):
+    def cutreeHybrid(dendro, distM, cutHeight=None, minClusterSize=20, deepSplit=1,
+                     maxCoreScatter=None, minGap=None, maxAbsCoreScatter=None,
+                     minAbsGap=None, minSplitHeight=None, minAbsSplitHeight=None,
+                     externalBranchSplitFnc=None, nExternalSplits=0, minExternalSplit=None,
+                     externalSplitOptions=pd.DataFrame(), externalSplitFncNeedsDistance=None,
+                     assumeSimpleExternalSpecification=True, pamStage=True,
+                     pamRespectsDendro=True, useMedoids=False, maxPamDist=None,
+                     respectSmallClusters=True):
         """
         Detect clusters in a dendorgram produced by the function hclust.
 
@@ -1598,13 +1310,10 @@ class WGCNA(GeneExp):
         if distM.shape[0] != nMerge + 1 or distM.shape[1] != nMerge + 1:
             sys.exit("distM has incorrect dimensions.")
         if pamRespectsDendro and not respectSmallClusters:
-            print(
-                "cutreeHybrid Warning: parameters pamRespectsDendro (TRUE) "
-                "and respectSmallClusters (FALSE) imply contradictory intent.\n"
-                "Although the code will work, please check you really intented "
-                "these settings for the two arguments.",
-                flush=True,
-            )
+            print("cutreeHybrid Warning: parameters pamRespectsDendro (TRUE) "
+                  "and respectSmallClusters (FALSE) imply contradictory intent.\n"
+                  "Although the code will work, please check you really intented "
+                  "these settings for the two arguments.", flush=True)
 
         print(f"{OKCYAN}Going through the merge tree...{ENDC}")
 
@@ -1617,12 +1326,8 @@ class WGCNA(GeneExp):
         refHeight = dendro[refMerge, 2]
         if cutHeight is None:
             cutHeight = 0.99 * (np.max(dendro_height) - refHeight) + refHeight
-            print(
-                "..cutHeight not given, setting it to",
-                round(cutHeight, 3),
-                " ===>  99% of the (truncated) height range in dendro.",
-                flush=True,
-            )
+            print("..cutHeight not given, setting it to", round(cutHeight, 3),
+                  " ===>  99% of the (truncated) height range in dendro.", flush=True)
         else:
             if cutHeight > np.max(dendro_height):
                 cutHeight = np.max(dendro_height)
@@ -1631,7 +1336,7 @@ class WGCNA(GeneExp):
         nMergeBelowCut = np.count_nonzero(dendro_height <= cutHeight)
         if nMergeBelowCut < minClusterSize:
             print("cutHeight set too low: no merges below the cut.", flush=True)
-            return pd.DataFrame({"labels": np.repeat(0, nMerge + 1, axis=0)})
+            return pd.DataFrame({'labels': np.repeat(0, nMerge + 1, axis=0)})
 
         if externalBranchSplitFnc is not None:
             nExternalSplits = len(externalBranchSplitFnc)
@@ -1641,12 +1346,9 @@ class WGCNA(GeneExp):
                 externalSplitOptions = pd.DataFrame(externalSplitOptions)
             # TODO: externalBranchSplitFnc = lapply(externalBranchSplitFnc, match.fun)
             for es in range(nExternalSplits):
-                externalSplitOptions["tree"][es] = dendro
-                if (
-                    len(externalSplitFncNeedsDistance) == 0
-                    or externalSplitFncNeedsDistance[es]
-                ):
-                    externalSplitOptions["dissimMat"][es] = distM
+                externalSplitOptions['tree'][es] = dendro
+                if len(externalSplitFncNeedsDistance) == 0 or externalSplitFncNeedsDistance[es]:
+                    externalSplitOptions['dissimMat'][es] = distM
 
         MxBranches = nMergeBelowCut
         branch_isBasic = np.repeat(True, MxBranches, axis=0)
@@ -1671,12 +1373,8 @@ class WGCNA(GeneExp):
         if isinstance(deepSplit, bool):
             deepSplit = pd.to_numeric(deepSplit) * (nSplitDefaults - 2)
         if deepSplit < 0 or deepSplit > nSplitDefaults:
-            msg = (
-                "Parameter deepSplit (value"
-                + str(deepSplit)
-                + ") out of range: allowable range is 0 through",
-                str(nSplitDefaults - 1),
-            )
+            msg = "Parameter deepSplit (value" + str(deepSplit) + \
+                  ") out of range: allowable range is 0 through", str(nSplitDefaults - 1)
             sys.exit(msg)
         if maxCoreScatter is None:
             maxCoreScatter = WGCNA.interpolate(defMCS, deepSplit)
@@ -1695,23 +1393,17 @@ class WGCNA(GeneExp):
         onBranch = np.repeat(0, nPoints, axis=0)
         RootBranch = 0
 
-        mergeDiagnostics = pd.DataFrame(
-            {
-                "smI": np.repeat(np.nan, nMerge, axis=0),
-                "smSize": np.repeat(np.nan, nMerge, axis=0),
-                "smCrSc": np.repeat(np.nan, nMerge, axis=0),
-                "smGap": np.repeat(np.nan, nMerge, axis=0),
-                "lgI": np.repeat(np.nan, nMerge, axis=0),
-                "lgSize": np.repeat(np.nan, nMerge, axis=0),
-                "lgCrSc": np.repeat(np.nan, nMerge, axis=0),
-                "lgGap": np.repeat(np.nan, nMerge, axis=0),
-                "merged": np.repeat(np.nan, nMerge, axis=0),
-            }
-        )
+        mergeDiagnostics = pd.DataFrame({'smI': np.repeat(np.nan, nMerge, axis=0),
+                                         'smSize': np.repeat(np.nan, nMerge, axis=0),
+                                         'smCrSc': np.repeat(np.nan, nMerge, axis=0),
+                                         'smGap': np.repeat(np.nan, nMerge, axis=0),
+                                         'lgI': np.repeat(np.nan, nMerge, axis=0),
+                                         'lgSize': np.repeat(np.nan, nMerge, axis=0),
+                                         'lgCrSc': np.repeat(np.nan, nMerge, axis=0),
+                                         'lgGap': np.repeat(np.nan, nMerge, axis=0),
+                                         'merged': np.repeat(np.nan, nMerge, axis=0)})
         if externalBranchSplitFnc is not None:
-            externalMergeDiags = pd.DataFrame(
-                np.nan, index=list(range(nMerge)), columns=list(range(nExternalSplits))
-            )
+            externalMergeDiags = pd.DataFrame(np.nan, index=list(range(nMerge)), columns=list(range(nExternalSplits)))
 
         extender = np.repeat(0, chunkSize, axis=0)
 
@@ -1721,28 +1413,17 @@ class WGCNA(GeneExp):
                     nBranches = nBranches + 1
                     branch_isBasic[nBranches - 1] = True
                     branch_isTopBasic[nBranches - 1] = True
-                    branch_singletons[nBranches - 1] = np.append(
-                        -1 * dendro_merge[merge, :], extender
-                    )
+                    branch_singletons[nBranches - 1] = np.append(-1 * dendro_merge[merge, :], extender)
                     branch_basicClusters[nBranches - 1] = extender
-                    branch_mergingHeights[nBranches - 1] = np.append(
-                        np.repeat(dendro_height[merge], 2), extender
-                    )
-                    branch_singletonHeights[nBranches - 1] = np.append(
-                        np.repeat(dendro_height[merge], 2), extender
-                    )
+                    branch_mergingHeights[nBranches - 1] = np.append(np.repeat(dendro_height[merge], 2), extender)
+                    branch_singletonHeights[nBranches - 1] = np.append(np.repeat(dendro_height[merge], 2), extender)
                     IndMergeToBranch[merge] = nBranches
                     RootBranch = nBranches
-                elif (
-                    np.sign(dendro_merge[merge, 0]) * np.sign(dendro_merge[merge, 1])
-                    < 0
-                ):
+                elif np.sign(dendro_merge[merge, 0]) * np.sign(dendro_merge[merge, 1]) < 0:
                     clust = IndMergeToBranch[int(np.max(dendro_merge[merge, :])) - 1]
 
                     if clust == 0:
-                        sys.exit(
-                            "Internal error: a previous merge has no associated cluster. Sorry!"
-                        )
+                        sys.exit("Internal error: a previous merge has no associated cluster. Sorry!")
 
                     gene = -1 * int(np.min(dendro_merge[merge, :]))
                     ns = branch_nSingletons[clust - 1] + 1
@@ -1750,23 +1431,15 @@ class WGCNA(GeneExp):
 
                     if branch_isBasic[clust - 1]:
                         if ns > len(branch_singletons[clust - 1]):
-                            branch_singletons[clust - 1] = np.append(
-                                branch_singletons[clust - 1], extender
-                            )
-                            branch_singletonHeights[clust - 1] = np.append(
-                                branch_singletonHeights[clust - 1], extender
-                            )
+                            branch_singletons[clust - 1] = np.append(branch_singletons[clust - 1], extender)
+                            branch_singletonHeights[clust - 1] = np.append(branch_singletonHeights[clust - 1], extender)
                         branch_singletons[clust - 1][ns - 1] = gene
-                        branch_singletonHeights[clust - 1][ns - 1] = dendro_height[
-                            merge
-                        ]
+                        branch_singletonHeights[clust - 1][ns - 1] = dendro_height[merge]
                     else:
                         onBranch[int(gene) - 1] = clust
 
                     if nm >= len(branch_mergingHeights[clust - 1]):
-                        branch_mergingHeights[clust - 1] = np.append(
-                            branch_mergingHeights[clust - 1], extender
-                        )
+                        branch_mergingHeights[clust - 1] = np.append(branch_mergingHeights[clust - 1], extender)
                     branch_mergingHeights[clust - 1][nm - 1] = dendro_height[merge]
                     branch_size[clust - 1] = branch_size[clust - 1] + 1
                     branch_nMerge[clust - 1] = nm
@@ -1782,65 +1455,45 @@ class WGCNA(GeneExp):
                     sizes = sizes[rnk - 1]
 
                     if branch_isBasic[small - 1]:
-                        coresize = WGCNA.coreSizeFunc(
-                            branch_nSingletons[small - 1], minClusterSize
-                        )
-                        Core = np.array(
-                            branch_singletons[small - 1][np.arange(coresize)] - 1,
-                            dtype=int,
-                        )
+                        coresize = WGCNA.coreSizeFunc(branch_nSingletons[small - 1], minClusterSize)
+                        Core = np.array(branch_singletons[small - 1][np.arange(coresize)] - 1, dtype=int)
                         SmAveDist = np.mean(distM.iloc[Core, Core].sum() / coresize - 1)
                     else:
                         SmAveDist = 0
 
                     if branch_isBasic[large - 1]:
-                        coresize = WGCNA.coreSizeFunc(
-                            branch_nSingletons[large - 1], minClusterSize
-                        )
-                        Core = np.array(
-                            branch_singletons[large - 1][np.arange(int(coresize))] - 1,
-                            dtype=int,
-                        )
+                        coresize = WGCNA.coreSizeFunc(branch_nSingletons[large - 1], minClusterSize)
+                        Core = np.array(branch_singletons[large - 1][np.arange(int(coresize))] - 1, dtype=int)
                         LgAveDist = np.mean(distM.iloc[Core, Core].sum() / coresize - 1)
                     else:
                         LgAveDist = 0
 
-                    mergeDiagnostics.loc[merge, :] = [
-                        small,
-                        branch_size[small - 1],
-                        SmAveDist,
-                        dendro_height[merge] - SmAveDist,
-                        large,
-                        branch_size[large - 1],
-                        LgAveDist,
-                        dendro_height[merge] - LgAveDist,
-                        None,
-                    ]
-                    SmallerScores = [
-                        branch_isBasic[small - 1],
-                        branch_size[small - 1] < minClusterSize,
-                        SmAveDist > maxAbsCoreScatter,
-                        dendro_height[merge] - SmAveDist < minAbsGap,
-                        dendro_height[merge] < minAbsSplitHeight,
-                    ]
+                    mergeDiagnostics.loc[merge, :] = [small,
+                                                      branch_size[small - 1],
+                                                      SmAveDist,
+                                                      dendro_height[merge] - SmAveDist,
+                                                      large,
+                                                      branch_size[large - 1],
+                                                      LgAveDist,
+                                                      dendro_height[merge] - LgAveDist,
+                                                      None]
+                    SmallerScores = [branch_isBasic[small - 1],
+                                     branch_size[small - 1] < minClusterSize,
+                                     SmAveDist > maxAbsCoreScatter,
+                                     dendro_height[merge] - SmAveDist < minAbsGap,
+                                     dendro_height[merge] < minAbsSplitHeight]
                     if SmallerScores[0] * np.count_nonzero(SmallerScores[1:]) > 0:
                         DoMerge = True
-                        SmallerFailSize = ~np.logical_or(
-                            SmallerScores[2], SmallerScores[3]
-                        )
+                        SmallerFailSize = ~np.logical_or(SmallerScores[2], SmallerScores[3])
                     else:
-                        LargerScores = [
-                            branch_isBasic[large - 1],
-                            branch_size[large - 1] < minClusterSize,
-                            LgAveDist > maxAbsCoreScatter,
-                            dendro_height[merge] - LgAveDist < minAbsGap,
-                            dendro_height[merge] < minAbsSplitHeight,
-                        ]
+                        LargerScores = [branch_isBasic[large - 1],
+                                        branch_size[large - 1] < minClusterSize,
+                                        LgAveDist > maxAbsCoreScatter,
+                                        dendro_height[merge] - LgAveDist < minAbsGap,
+                                        dendro_height[merge] < minAbsSplitHeight]
                         if LargerScores[0] * np.count_nonzero(LargerScores[1:]) > 0:
                             DoMerge = True
-                            SmallerFailSize = ~np.logical_or(
-                                LargerScores[2], LargerScores[3]
-                            )
+                            SmallerFailSize = ~np.logical_or(LargerScores[2], LargerScores[3])
                             x = small
                             small = large
                             large = x
@@ -1849,35 +1502,23 @@ class WGCNA(GeneExp):
                             DoMerge = False
 
                     if DoMerge:
-                        mergeDiagnostics["merged"][merge] = 1
+                        mergeDiagnostics['merged'][merge] = 1
 
-                    if (
-                        not DoMerge
-                        and nExternalSplits > 0
-                        and branch_isBasic[small - 1]
-                        and branch_isBasic[large - 1]
-                    ):
+                    if not DoMerge and nExternalSplits > 0 and branch_isBasic[small - 1] and branch_isBasic[large - 1]:
                         branch1 = branch_singletons[large - 1][np.arange(sizes[1])]
                         branch2 = branch_singletons[small - 1][np.arange(sizes[0])]
                         es = 0
                         while es < nExternalSplits and not DoMerge:
                             es = es + 1
-                            args = pd.DataFrame(
-                                {
-                                    "externalSplitOptions": externalSplitOptions[
-                                        es - 1
-                                    ],
-                                    "branch1": branch1,
-                                    "branch2": branch2,
-                                }
-                            )
+                            args = pd.DataFrame({'externalSplitOptions': externalSplitOptions[es - 1],
+                                                 'branch1': branch1, 'branch2': branch2})
                             # TODO: extSplit = do.call(externalBranchSplitFnc[[es]], args)
                             extSplit = None
                             DoMerge = extSplit < minExternalSplit[es - 1]
                             externalMergeDiags[merge, es - 1] = extSplit
-                            mergeDiagnostics["merged"][merge] = 0
+                            mergeDiagnostics['merged'][merge] = 0
                             if DoMerge:
-                                mergeDiagnostics["merged"][merge] = 2
+                                mergeDiagnostics['merged'][merge] = 2
 
                     if DoMerge:
                         branch_failSize[small - 1] = SmallerFailSize
@@ -1889,51 +1530,32 @@ class WGCNA(GeneExp):
                         ns = nss + nsl
 
                         if branch_isBasic[large - 1]:
-                            nExt = np.ceil(
-                                (ns - len(branch_singletons[large - 1])) / chunkSize
-                            )
+                            nExt = np.ceil((ns - len(branch_singletons[large - 1])) / chunkSize)
                             if nExt > 0:
-                                branch_singletons[large - 1] = np.append(
-                                    branch_singletons[large - 1],
-                                    np.repeat(extender, nExt),
-                                )
-                                branch_singletonHeights[large - 1] = np.append(
-                                    branch_singletonHeights[large - 1],
-                                    np.repeat(extender, nExt),
-                                )
+                                branch_singletons[large - 1] = np.append(branch_singletons[large - 1],
+                                                                         np.repeat(extender, nExt))
+                                branch_singletonHeights[large - 1] = np.append(branch_singletonHeights[large - 1],
+                                                                               np.repeat(extender, nExt))
 
-                            branch_singletons[large - 1][np.arange(nsl, ns)] = (
-                                branch_singletons[small - 1][np.arange(nss)]
-                            )
-                            branch_singletonHeights[large - 1][np.arange(nsl, ns)] = (
-                                branch_singletonHeights[small - 1][np.arange(nss)]
-                            )
+                            branch_singletons[large - 1][np.arange(nsl, ns)] = branch_singletons[small - 1][
+                                np.arange(nss)]
+                            branch_singletonHeights[large - 1][np.arange(nsl, ns)] = branch_singletonHeights[small - 1][
+                                np.arange(nss)]
                             branch_nSingletons[large] = ns
                         else:
                             if not branch_isBasic[small - 1]:
-                                sys.exit(
-                                    "Internal error: merging two composite clusters. Sorry!"
-                                )
+                                sys.exit("Internal error: merging two composite clusters. Sorry!")
 
-                            onBranch[
-                                branch_singletons[small - 1][
-                                    branch_singletons[small - 1] != 0
-                                ]
-                                - 1
-                            ] = large
+                            onBranch[branch_singletons[small - 1][branch_singletons[small - 1] != 0] - 1] = large
 
                         nm = branch_nMerge[large - 1] + 1
 
                         if nm > len(branch_mergingHeights[large - 1]):
-                            branch_mergingHeights[large - 1] = np.append(
-                                branch_mergingHeights[large - 1], extender
-                            )
+                            branch_mergingHeights[large - 1] = np.append(branch_mergingHeights[large - 1], extender)
 
                         branch_mergingHeights[large - 1][nm - 1] = dendro_height[merge]
                         branch_nMerge[large - 1] = nm
-                        branch_size[large - 1] = (
-                            branch_size[small - 1] + branch_size[large - 1]
-                        )
+                        branch_size[large - 1] = branch_size[small - 1] + branch_size[large - 1]
                         IndMergeToBranch[merge] = large
                         RootBranch = large
                     else:
@@ -1943,13 +1565,9 @@ class WGCNA(GeneExp):
                             small = x
                             sizes = np.flip(sizes)
 
-                        if branch_isBasic[large - 1] or (
-                            pamStage and pamRespectsDendro
-                        ):
+                        if branch_isBasic[large - 1] or (pamStage and pamRespectsDendro):
                             nBranches = nBranches + 1
-                            branch_attachHeight[[large - 1, small - 1]] = dendro_height[
-                                merge
-                            ]
+                            branch_attachHeight[[large - 1, small - 1]] = dendro_height[merge]
                             branch_mergedInto[[large - 1, small - 1]] = nBranches
                             if branch_isBasic[small - 1]:
                                 addBasicClusters = small
@@ -1958,59 +1576,37 @@ class WGCNA(GeneExp):
                             if branch_isBasic[large - 1]:
                                 addBasicClusters = np.append(addBasicClusters, large)
                             else:
-                                addBasicClusters = np.append(
-                                    addBasicClusters, branch_basicClusters[large - 1]
-                                )
+                                addBasicClusters = np.append(addBasicClusters, branch_basicClusters[large - 1])
                             branch_isBasic[nBranches - 1] = False
                             branch_isTopBasic[nBranches - 1] = False
                             branch_basicClusters[nBranches - 1] = addBasicClusters
-                            branch_mergingHeights[nBranches - 1] = np.append(
-                                np.repeat(dendro_height[merge], 2), extender
-                            )
+                            branch_mergingHeights[nBranches - 1] = np.append(np.repeat(dendro_height[merge], 2),
+                                                                             extender)
                             branch_nMerge[nBranches - 1] = 2
                             branch_size[nBranches - 1] = np.sum(sizes)
                             branch_nBasicClusters[nBranches - 1] = len(addBasicClusters)
                             IndMergeToBranch[merge] = nBranches
                             RootBranch = nBranches
                         else:
-                            addBasicClusters = (
-                                [small]
-                                if branch_isBasic[small - 1]
-                                else branch_basicClusters[small - 1]
-                            )
+                            addBasicClusters = [small] if branch_isBasic[small - 1] else branch_basicClusters[small - 1]
 
                             nbl = branch_nBasicClusters[large - 1]
-                            nb = branch_nBasicClusters[large - 1] + len(
-                                addBasicClusters
-                            )
+                            nb = branch_nBasicClusters[large - 1] + len(addBasicClusters)
 
                             if nb > len(branch_basicClusters[large - 1]):
-                                nExt = np.ceil(
-                                    (nb - len(branch_basicClusters[large - 1]))
-                                    / chunkSize
-                                )
-                                branch_basicClusters[large - 1] = np.append(
-                                    branch_basicClusters[large - 1],
-                                    np.repeat(extender, nExt),
-                                )
+                                nExt = np.ceil((nb - len(branch_basicClusters[large - 1])) / chunkSize)
+                                branch_basicClusters[large - 1] = np.append(branch_basicClusters[large - 1],
+                                                                            np.repeat(extender, nExt))
 
-                            branch_basicClusters[large - 1][np.arange(nbl, nb)] = (
-                                addBasicClusters
-                            )
+                            branch_basicClusters[large - 1][np.arange(nbl, nb)] = addBasicClusters
                             branch_nBasicClusters[large - 1] = nb
-                            branch_size[large - 1] = (
-                                branch_size[large - 1] + branch_size[small - 1]
-                            )
+                            branch_size[large - 1] = branch_size[large - 1] + branch_size[small - 1]
                             nm = branch_nMerge[large - 1] + 1
 
                             if nm > len(branch_mergingHeights[large - 1]):
-                                branch_mergingHeights[large - 1] = np.append(
-                                    branch_mergingHeights[large - 1], extender
-                                )
+                                branch_mergingHeights[large - 1] = np.append(branch_mergingHeights[large - 1], extender)
 
-                            branch_mergingHeights[large - 1][nm - 1] = dendro_height[
-                                merge
-                            ]
+                            branch_mergingHeights[large - 1][nm - 1] = dendro_height[merge]
                             branch_nMerge[large - 1] = nm
                             branch_attachHeight[small - 1] = dendro_height[merge]
                             branch_mergedInto[small - 1] = large
@@ -2025,16 +1621,11 @@ class WGCNA(GeneExp):
                 branch_attachHeight[clust] = cutHeight
             if branch_isTopBasic[clust]:
                 coresize = WGCNA.coreSizeFunc(branch_nSingletons[clust], minClusterSize)
-                Core = np.array(
-                    branch_singletons[clust][np.arange(coresize)] - 1, dtype=int
-                )
+                Core = np.array(branch_singletons[clust][np.arange(coresize)] - 1, dtype=int)
                 CoreScatter = np.mean(distM.iloc[Core, Core].sum() / (coresize - 1))
-                isCluster[clust] = (
-                    branch_isTopBasic[clust]
-                    and branch_size[clust] >= minClusterSize
-                    and CoreScatter < maxAbsCoreScatter
-                    and branch_attachHeight[clust] - CoreScatter > minAbsGap
-                )
+                isCluster[clust] = (branch_isTopBasic[clust] and branch_size[clust] >= minClusterSize and
+                                    CoreScatter < maxAbsCoreScatter and branch_attachHeight[
+                                        clust] - CoreScatter > minAbsGap)
             else:
                 CoreScatter = 0
             if branch_failSize[clust]:
@@ -2054,9 +1645,7 @@ class WGCNA(GeneExp):
             Colors[branch_singletons[clust][branch_singletons[clust] != 0] - 1] = color
             SmallLabels[branch_singletons[clust][branch_singletons[clust] != 0] - 1] = 0
             coresize = WGCNA.coreSizeFunc(branch_nSingletons[clust], minClusterSize)
-            Core = np.array(
-                branch_singletons[clust][np.arange(coresize)] - 1, dtype=int
-            )
+            Core = np.array(branch_singletons[clust][np.arange(coresize)] - 1, dtype=int)
             coreLabels[Core] = color
             branchLabels[clust] = color
 
@@ -2081,16 +1670,12 @@ class WGCNA(GeneExp):
                     DistInCluster = distM.iloc[InCluster - 1, InCluster - 1]
                     DistSums = DistInCluster.sum(axis=0)
                     Medoids[cluster - 1] = InCluster[DistSums.idxmin()]
-                    ClusterRadii[cluster - 1] = np.max(
-                        DistInCluster[:, DistSums.idxmin()]
-                    )
+                    ClusterRadii[cluster - 1] = np.max(DistInCluster[:, DistSums.idxmin()])
 
                 if respectSmallClusters:
                     FSmallLabels = pd.Categorical(SmallLabels)
                     SmallLabLevs = pd.to_numeric(FSmallLabels.categories)
-                    nSmallClusters = len(FSmallLabels.categories) - (
-                        SmallLabLevs[1] == 0
-                    )
+                    nSmallClusters = len(FSmallLabels.categories) - (SmallLabLevs[1] == 0)
 
                     if nSmallClusters > 0:
                         for sclust in SmallLabLevs[SmallLabLevs != 0]:
@@ -2098,10 +1683,8 @@ class WGCNA(GeneExp):
                             if pamRespectsDendro:
                                 onBr = np.unique(onBranch[InCluster])
                                 if len(onBr) > 1:
-                                    msg = (
-                                        "Internal error: objects in a small cluster are marked to belong\n "
-                                        "to several large branches:" + str(onBr)
-                                    )
+                                    msg = "Internal error: objects in a small cluster are marked to belong\n " \
+                                          "to several large branches:" + str(onBr)
                                     sys.exit(msg)
 
                                 if onBr > 0:
@@ -2118,16 +1701,11 @@ class WGCNA(GeneExp):
                                 if len(InCluster) > 1:
                                     DistSums = DistInCluster.sum(axis=1)
                                     smed = InCluster[DistSums.idxmin()]
-                                    DistToMeds = distM.iloc[
-                                        Medoids[labelsOnBranch - 1] - 1, smed
-                                    ]
+                                    DistToMeds = distM.iloc[Medoids[labelsOnBranch - 1] - 1, smed]
                                     closest = DistToMeds.idxmin()
                                     DistToClosest = DistToMeds[closest]
                                     closestLabel = labelsOnBranch[closest]
-                                    if (
-                                        DistToClosest < ClusterRadii[closestLabel - 1]
-                                        or DistToClosest < maxPamDist
-                                    ):
+                                    if DistToClosest < ClusterRadii[closestLabel - 1] or DistToClosest < maxPamDist:
                                         Colors[InCluster] = closestLabel
                                         nPAMed = nPAMed + len(InCluster)
                                 else:
@@ -2149,19 +1727,14 @@ class WGCNA(GeneExp):
                             labelsOnBranch = np.arange(nProperLabels)
 
                         if labelsOnBranch is not None:
-                            UnassdToMedoidDist = distM.iloc[
-                                Medoids[labelsOnBranch - 1] - 1, obj
-                            ]
+                            UnassdToMedoidDist = distM.iloc[Medoids[labelsOnBranch - 1] - 1, obj]
                             nearest = UnassdToMedoidDist.idxmin()
                             NearestCenterDist = UnassdToMedoidDist[nearest]
                             nearestMed = labelsOnBranch[nearest]
-                            if (
-                                NearestCenterDist < ClusterRadii[nearestMed - 1]
-                                or NearestCenterDist < maxPamDist
-                            ):
+                            if NearestCenterDist < ClusterRadii[nearestMed - 1] or NearestCenterDist < maxPamDist:
                                 Colors[obj] = nearestMed
                                 nPAMed = nPAMed + 1
-                    UnlabeledExist = sum(Colors == 0) > 0
+                    UnlabeledExist = (sum(Colors == 0) > 0)
             else:
                 ClusterDiam = np.zeros((nProperLabels,))
                 for cluster in range(nProperLabels):
@@ -2179,19 +1752,15 @@ class WGCNA(GeneExp):
                 if respectSmallClusters:
                     FSmallLabels = pd.Categorical(SmallLabels)
                     SmallLabLevs = pd.to_numeric(FSmallLabels.categories)
-                    nSmallClusters = len(FSmallLabels.categories) - (
-                        SmallLabLevs[0] == 0
-                    )
+                    nSmallClusters = len(FSmallLabels.categories) - (SmallLabLevs[0] == 0)
                     if nSmallClusters > 0:
                         if pamRespectsDendro:
                             for sclust in SmallLabLevs[SmallLabLevs != 0]:
                                 InCluster = np.where(SmallLabels == sclust)[0].tolist()
                                 onBr = pd.unique(onBranch[InCluster])
                                 if len(onBr) > 1:
-                                    msg = (
-                                        "Internal error: objects in a small cluster are marked to belong\n"
-                                        "to several large branches:" + str(onBr)
-                                    )
+                                    msg = "Internal error: objects in a small cluster are marked to belong\n" \
+                                          "to several large branches:" + str(onBr)
                                     sys.exit(msg)
                                 if onBr > 0:
                                     basicOnBranch = branch_basicClusters[onBr[0] - 1]
@@ -2199,27 +1768,14 @@ class WGCNA(GeneExp):
                                     useObjects = ColorsX in np.unique(labelsOnBranch)
                                     DistSClustClust = distM.iloc[InCluster, useObjects]
                                     MeanDist = DistSClustClust.mean(axis=0)
-                                    useColorsFac = ColorsX[
-                                        useObjects
-                                    ]  # pd.Categorical(ColorsX[useObjects])
-                                    MeanDist = pd.DataFrame(
-                                        {
-                                            "MeanDist": MeanDist,
-                                            "useColorsFac": useColorsFac,
-                                        }
-                                    )
+                                    useColorsFac = ColorsX[useObjects]  # pd.Categorical(ColorsX[useObjects])
+                                    MeanDist = pd.DataFrame({'MeanDist': MeanDist, 'useColorsFac': useColorsFac})
                                     MeanMeanDist = MeanDist.groupby(
-                                        "useColorsFac"
-                                    ).mean()  # tapply(MeanDist, useColorsFac, mean)
-                                    nearest = (
-                                        MeanMeanDist[["MeanDist"]].idxmin().astype(int)
-                                        - 1
-                                    )
-                                    NearestDist = MeanMeanDist[["MeanDist"]].min()
-                                    if np.logical_or(
-                                        np.all(NearestDist < ClusterDiam[nearest]),
-                                        NearestDist < maxPamDist,
-                                    ).tolist()[0]:
+                                        'useColorsFac').mean()  # tapply(MeanDist, useColorsFac, mean)
+                                    nearest = MeanMeanDist[['MeanDist']].idxmin().astype(int) - 1
+                                    NearestDist = MeanMeanDist[['MeanDist']].min()
+                                    if np.logical_or(np.all(NearestDist < ClusterDiam[nearest]),
+                                                     NearestDist < maxPamDist).tolist()[0]:
                                         Colors[InCluster] = nearest
                                         nPAMed = nPAMed + len(InCluster)
                                     else:
@@ -2231,23 +1787,14 @@ class WGCNA(GeneExp):
                                 InCluster = np.where(SmallLabels == sclust)[0].tolist()
                                 DistSClustClust = distM.iloc[InCluster, useObjects]
                                 MeanDist = DistSClustClust.mean(axis=0)
-                                useColorsFac = ColorsX[
-                                    useObjects
-                                ]  # pd.Categorical(ColorsX[useObjects])
-                                MeanDist = pd.DataFrame(
-                                    {"MeanDist": MeanDist, "useColorsFac": useColorsFac}
-                                )
+                                useColorsFac = ColorsX[useObjects]  # pd.Categorical(ColorsX[useObjects])
+                                MeanDist = pd.DataFrame({'MeanDist': MeanDist, 'useColorsFac': useColorsFac})
                                 MeanMeanDist = MeanDist.groupby(
-                                    "useColorsFac"
-                                ).mean()  # tapply(MeanDist, useColorsFac, mean)
-                                nearest = (
-                                    MeanMeanDist[["MeanDist"]].idxmin().astype(int) - 1
-                                )
-                                NearestDist = MeanMeanDist[["MeanDist"]].min()
-                                if np.logical_or(
-                                    np.all(NearestDist < ClusterDiam[nearest]),
-                                    NearestDist < maxPamDist,
-                                ).tolist()[0]:
+                                    'useColorsFac').mean()  # tapply(MeanDist, useColorsFac, mean)
+                                nearest = MeanMeanDist[['MeanDist']].idxmin().astype(int) - 1
+                                NearestDist = MeanMeanDist[['MeanDist']].min()
+                                if np.logical_or(np.all(NearestDist < ClusterDiam[nearest]),
+                                                 NearestDist < maxPamDist).tolist()[0]:
                                     Colors[InCluster] = nearest
                                     nPAMed = nPAMed + len(InCluster)
                                 else:
@@ -2262,82 +1809,52 @@ class WGCNA(GeneExp):
                                 basicOnBranch = branch_basicClusters[onBr - 1]
                                 labelsOnBranch = branchLabels[basicOnBranch - 1]
                                 useObjects = ColorsX in np.unique(labelsOnBranch)
-                                useColorsFac = ColorsX[
-                                    useObjects
-                                ]  # pd.Categorical(ColorsX[useObjects])
-                                UnassdToClustDist = (
-                                    distM.iloc[useObjects, obj]
-                                    .groupby("useColorsFac")
-                                    .mean()
-                                )  # tapply(distM[useObjects, obj], useColorsFac, mean)
+                                useColorsFac = ColorsX[useObjects]  # pd.Categorical(ColorsX[useObjects])
+                                UnassdToClustDist = distM.iloc[useObjects, obj].groupby(
+                                    'useColorsFac').mean()  # tapply(distM[useObjects, obj], useColorsFac, mean)
                                 nearest = UnassdToClustDist.idxmin().astype(int) - 1
                                 NearestClusterDist = UnassdToClustDist[nearest]
-                                nearestLabel = pd.to_numeric(
-                                    useColorsFac.categories[nearest]
-                                )
-                                if np.logical_or(
-                                    np.all(NearestClusterDist < ClusterDiam[nearest]),
-                                    NearestClusterDist < maxPamDist,
-                                ).tolist()[0]:
+                                nearestLabel = pd.to_numeric(useColorsFac.categories[nearest])
+                                if np.logical_or(np.all(NearestClusterDist < ClusterDiam[nearest]),
+                                                 NearestClusterDist < maxPamDist).tolist()[0]:
                                     Colors[obj] = nearest
                                     nPAMed = nPAMed + 1
                             else:
                                 labelsOnBranch = None
                     else:
                         useObjects = np.where(ColorsX != 0)[0].tolist()
-                        useColorsFac = ColorsX[
-                            useObjects
-                        ]  # pd.Categorical(ColorsX[useObjects])
+                        useColorsFac = ColorsX[useObjects]  # pd.Categorical(ColorsX[useObjects])
                         tmp = pd.DataFrame(distM.iloc[useObjects, Unlabeled])
-                        tmp["group"] = useColorsFac
+                        tmp['group'] = useColorsFac
                         UnassdToClustDist = tmp.groupby(
-                            ["group"]
-                        ).mean()  # apply(distM[useObjects, Unlabeled], 2, tapply, useColorsFac, mean)
-                        nearest = np.subtract(
-                            UnassdToClustDist.idxmin(axis=0),
-                            np.ones(UnassdToClustDist.shape[1]),
-                        ).astype(int)  # apply(UnassdToClustDist, 2, which.min)
-                        nearestDist = UnassdToClustDist.min(
-                            axis=0
-                        )  # apply(UnassdToClustDist, 2, min)
+                            ['group']).mean()  # apply(distM[useObjects, Unlabeled], 2, tapply, useColorsFac, mean)
+                        nearest = np.subtract(UnassdToClustDist.idxmin(axis=0),
+                                              np.ones(UnassdToClustDist.shape[1])).astype(
+                            int)  # apply(UnassdToClustDist, 2, which.min)
+                        nearestDist = UnassdToClustDist.min(axis=0)  # apply(UnassdToClustDist, 2, min)
                         nearestLabel = nearest + 1
-                        sumAssign = np.sum(
-                            np.logical_or(
-                                nearestDist < ClusterDiam[nearest],
-                                nearestDist < maxPamDist,
-                            )
-                        )
-                        assign = np.where(
-                            np.logical_or(
-                                nearestDist < ClusterDiam[nearest],
-                                nearestDist < maxPamDist,
-                            )
-                        )[0].tolist()
+                        sumAssign = np.sum(np.logical_or(nearestDist < ClusterDiam[nearest], nearestDist < maxPamDist))
+                        assign = np.where(np.logical_or(nearestDist < ClusterDiam[nearest], nearestDist < maxPamDist))[
+                            0].tolist()
                         tmp = [Unlabeled[x] for x in assign]
                         Colors[tmp] = [nearestLabel.iloc[x] for x in assign]
                         nPAMed = nPAMed + sumAssign
 
         Colors[np.where(Colors < 0)[0].tolist()] = 0
-        UnlabeledExist = np.count_nonzero(Colors == 0) > 0
+        UnlabeledExist = (np.count_nonzero(Colors == 0) > 0)
         NumLabs = list(map(int, Colors.copy()))
         Sizes = pd.DataFrame(NumLabs).value_counts().sort_index()
-        OrdNumLabs = pd.DataFrame(
-            {"Name": NumLabs, "Value": np.repeat(1, len(NumLabs))}
-        )
+        OrdNumLabs = pd.DataFrame({"Name": NumLabs, "Value": np.repeat(1, len(NumLabs))})
 
         if UnlabeledExist:
             if len(Sizes) > 1:
-                SizeRank = np.insert(
-                    stats.rankdata(-1 * Sizes[1 : len(Sizes)], method="ordinal") + 1,
-                    0,
-                    1,
-                )
+                SizeRank = np.insert(stats.rankdata(-1 * Sizes[1:len(Sizes)], method='ordinal') + 1, 0, 1)
             else:
                 SizeRank = [1]
             for i in range(len(NumLabs)):
                 OrdNumLabs.Value[i] = SizeRank[NumLabs[i] - 1]
         else:
-            SizeRank = stats.rankdata(-1 * Sizes, method="ordinal")
+            SizeRank = stats.rankdata(-1 * Sizes, method='ordinal')
             for i in range(len(NumLabs)):
                 OrdNumLabs.Value[i] = SizeRank[NumLabs[i] - 1]
 
@@ -2365,15 +1882,12 @@ class WGCNA(GeneExp):
         """
         if colorSeq is None:
             colors = mcolors.CSS4_COLORS
-            colors = pd.DataFrame(
-                {"name": list(colors.keys()), "color": list(colors.values())}
-            )
-            colors.drop_duplicates(subset="color", keep="last", inplace=True)
+            colors = pd.DataFrame({"name": list(colors.keys()),
+                                   "color": list(colors.values())})
+            colors.drop_duplicates(subset='color', keep="last", inplace=True)
             # Sort colors by hue, saturation, value and name.
-            by_hsv = sorted(
-                (tuple(mcolors.rgb_to_hsv(mcolors.to_rgba(color)[:3])), name)
-                for name, color in colors.itertuples(index=False)
-            )
+            by_hsv = sorted((tuple(mcolors.rgb_to_hsv(mcolors.to_rgba(color)[:3])), name)
+                            for name, color in colors.itertuples(index=False))
             colorSeq = [name for hsv, name in by_hsv]
             colorSeq.remove(naColor)
 
@@ -2391,10 +1905,8 @@ class WGCNA(GeneExp):
 
         if np.max(nLabels.Value) > len(colorSeq):
             nRepeats = int((np.max(labels.Value) - 1) / len(colorSeq)) + 1
-            print(
-                f"{WARNING}labels2colors: Number of labels exceeds number of avilable colors.\n"
-                f"Some colors will be repeated {str(nRepeats)} times.{ENDC}"
-            )
+            print(f"{WARNING}labels2colors: Number of labels exceeds number of avilable colors.\n"
+                  f"Some colors will be repeated {str(nRepeats)} times.{ENDC}")
             extColorSeq = colorSeq
             for rep in range(nRepeats):
                 tmp = [str(item) + "." + str(rep) for item in colorSeq]
@@ -2412,19 +1924,8 @@ class WGCNA(GeneExp):
         return colors
 
     @staticmethod
-    def moduleEigengenes(
-        expr,
-        colors,
-        impute=True,
-        nPC=1,
-        align="along average",
-        excludeGrey=False,
-        grey="grey",
-        subHubs=True,
-        softPower=6,
-        scaleVar=True,
-        trapErrors=False,
-    ):
+    def moduleEigengenes(expr, colors, impute=True, nPC=1, align="along average", excludeGrey=False, grey="grey",
+                         subHubs=True, softPower=6, scaleVar=True, trapErrors=False):
         """
         Calculates module eigengenes (1st principal component) of modules in a given single dataset.
 
@@ -2454,9 +1955,7 @@ class WGCNA(GeneExp):
         :return: A dictionary containing: "eigengenes": Module eigengenes in a dataframe, with each column corresponding to one eigengene. The columns are named by the corresponding color with an "ME" prepended, e.g., MEturquoise etc. If returnValidOnly==FALSE, module eigengenes whose calculation failed have all components set to NA. "averageExpr": If align == "along average", a dataframe containing average normalized expression in each module. The columns are named by the corresponding color with an "AE" prepended, e.g., AEturquoise etc. "varExplained": A dataframe in which each column corresponds to a module, with the component varExplained[PC, module] giving the variance of module module explained by the principal component no. PC. The calculation is exact irrespective of the number of computed principal components. At most 10 variance explained values are recorded in this dataframe. "nPC": A copy of the input nPC. "validMEs": A boolean vector. Each component (corresponding to the columns in data) is TRUE if the corresponding eigengene is valid, and FALSE if it is invalid. Valid eigengenes include both principal components and their hubgene approximations. When returnValidOnly==FALSE, by definition all returned eigengenes are valid and the entries of validMEs are all TRUE. "validColors": A copy of the input colors with entries corresponding to invalid modules set to grey if given, otherwise 0 if colors is numeric and "grey" otherwise. "allOK": Boolean flag signalling whether all eigengenes have been calculated correctly, either as principal components or as the hubgene average approximation. "allPC": Boolean flag signalling whether all returned eigengenes are principal components. "isPC": Boolean vector. Each component (corresponding to the columns in eigengenes) is TRUE if the corresponding eigengene is the first principal component and FALSE if it is the hubgene approximation or is invalid. "isHub": Boolean vector. Each component (corresponding to the columns in eigengenes) is TRUE if the corresponding eigengene is the hubgene approximation and FALSE if it is the first principal component or is invalid. "validAEs": Boolean vector. Each component (corresponding to the columns in eigengenes) is TRUE if the corresponding module average expression is valid. "allAEOK": Boolean flag signalling whether all returned module average expressions contain valid data. Note that returnValidOnly==TRUE does not imply allAEOK==TRUE: some invalid average expressions may be returned if their corresponding eigengenes have been calculated correctly.
         :rtype: dict
         """
-        print(
-            f"{OKCYAN}Calculating {len(pd.Categorical(colors).categories)} module eigengenes in given set...{ENDC}"
-        )
+        print(f"{OKCYAN}Calculating {len(pd.Categorical(colors).categories)} module eigengenes in given set...{ENDC}")
         check = True
         pc = None
         returnValidOnly = trapErrors
@@ -2467,35 +1966,28 @@ class WGCNA(GeneExp):
         if colors is None:
             sys.exit("moduleEigengenes: Error: colors is NULL.")
         if isinstance(expr, dict):
-            expr = expr["data"]
+            expr = expr['data']
         if expr.shape is None or len(expr.shape) != 2:
             sys.exit("moduleEigengenes: Error: expr must be two-dimensional.")
         if expr.shape[1] != len(colors):
-            sys.exit(
-                "moduleEigengenes: Error: ncol(expr) and length(colors) must be equal (one color per gene)."
-            )
+            sys.exit("moduleEigengenes: Error: ncol(expr) and length(colors) must be equal (one color per gene).")
         if len(pd.Categorical(colors).categories) == 1:
             sys.exit(
-                f"{WARNING}All your genes ended up in one modules! Reconsider your input parameters in order to get more modules.{ENDC}"
-            )
+                f"{WARNING}All your genes ended up in one modules! Reconsider your input parameters in order to get more modules.{ENDC}")
         # TODO: "Argument 'colors' contains unused levels (empty modules). Use colors[, drop=TRUE] to get rid of them."
         if softPower < 0:
             sys.exit("softPower must be non-negative")
         maxVarExplained = 10
         if nPC > maxVarExplained:
-            print(
-                f"{WARNING}Given nPC is too large. Will use value {str(maxVarExplained)}{ENDC}"
-            )
+            print(f"{WARNING}Given nPC is too large. Will use value {str(maxVarExplained)}{ENDC}")
         nVarExplained = min(nPC, maxVarExplained)
         modlevels = pd.Categorical(colors).categories
         if excludeGrey:
             if len(np.where(modlevels != grey)) > 0:
                 modlevels = modlevels[np.where(modlevels != grey)]
             else:
-                sys.exit(
-                    "Color levels are empty. Possible reason: the only color is grey and grey module is excluded "
-                    "from the calculation."
-                )
+                sys.exit("Color levels are empty. Possible reason: the only color is grey and grey module is excluded "
+                         "from the calculation.")
         PrinComps = np.empty((expr.shape[0], len(modlevels)))
         PrinComps[:] = np.nan
         PrinComps = pd.DataFrame(PrinComps)
@@ -2517,7 +2009,7 @@ class WGCNA(GeneExp):
             averExpr.index = expr.index
         for i in range(len(modlevels)):
             modulename = modlevels[i]
-            restrict1 = colors == modulename
+            restrict1 = (colors == modulename)
             datModule = expr.loc[:, restrict1].T
             n = datModule.shape[0]
             p = datModule.shape[1]
@@ -2526,63 +2018,39 @@ class WGCNA(GeneExp):
                     seedSaved = True
                     if datModule.isnull().values.any():
                         # define imputer
-                        imputer = KNNImputer(
-                            n_neighbors=np.min(10, datModule.shape[0] - 1)
-                        )
+                        imputer = KNNImputer(n_neighbors=np.min(10, datModule.shape[0] - 1))
                         # fit on the dataset
                         imputer.fit(datModule)
                         # transform the dataset
                         datModule = imputer.transform(
-                            datModule
-                        )  # datModule = impute.knn(datModule, k = min(10, nrow(datModule) - 1))
+                            datModule)  # datModule = impute.knn(datModule, k = min(10, nrow(datModule) - 1))
                 if scaleVar:
-                    datModule = pd.DataFrame(
-                        scale(datModule.T).T,
-                        index=datModule.index,
-                        columns=datModule.columns,
-                    )
+                    datModule = pd.DataFrame(scale(datModule.T).T, index=datModule.index, columns=datModule.columns)
                 u, d, v = np.linalg.svd(datModule)
-                u = u[:, 0 : min(n, p, nPC)]
-                v = v[0 : min(n, p, nPC), :]
+                u = u[:, 0:min(n, p, nPC)]
+                v = v[0:min(n, p, nPC), :]
                 tmp = datModule.copy()
-                tmp = pd.concat(
-                    [
-                        tmp,
-                        pd.DataFrame(
-                            v[0 : min(n, p, nVarExplained), :],
-                            columns=tmp.columns.tolist(),
-                        ),
-                    ],
-                    ignore_index=True,
-                )
+                tmp = pd.concat([tmp, pd.DataFrame(v[0:min(n, p, nVarExplained), :],
+                                                   columns=tmp.columns.tolist())],
+                                ignore_index=True)
                 veMat = pd.DataFrame(np.corrcoef(tmp.values)).iloc[:-1, -1].T
-                varExpl.iloc[0 : min(n, p, nVarExplained), i] = (veMat**2).mean(axis=0)
+                varExpl.iloc[0:min(n, p, nVarExplained), i] = (veMat ** 2).mean(axis=0)
                 pc = v[0].tolist()
             except:
                 if not subHubs:
                     sys.exit("Error!")
                 if subHubs:
-                    print(
-                        " ..principal component calculation for module",
-                        modulename,
-                        "failed with the following error:",
-                        flush=True,
-                    )
-                    print(
-                        "     ..hub genes will be used instead of principal components.",
-                        flush=True,
-                    )
+                    print(" ..principal component calculation for module", modulename,
+                          "failed with the following error:", flush=True)
+                    print("     ..hub genes will be used instead of principal components.", flush=True)
 
                     isPC[i] = False
                     check = True
                     try:
-                        scaledExpr = pd.DataFrame(
-                            scale(datModule.T).T,
-                            index=datModule.index,
-                            columns=datModule.columns,
-                        )
+                        scaledExpr = pd.DataFrame(scale(datModule.T).T, index=datModule.index,
+                                                  columns=datModule.columns)
                         covEx = np.cov(scaledExpr)
-                        covEx[~np.isfinite(covEx)] = 0
+                        covEx[~ np.isfinite(covEx)] = 0
                         modAdj = np.abs(covEx) ** softPower
                         kIM = (modAdj.mean(axis=0)) ** 3
                         if np.max(kIM) > 1:
@@ -2596,28 +2064,18 @@ class WGCNA(GeneExp):
                         tmp.shape = scaledExpr.shape
                         pcxMat = scaledExpr * tmp / sum(kIM)
                         pcx = pcxMat.mean(axis=0)
-                        varExpl[0, i] = np.mean(
-                            np.corrcoef(pcx, datModule.transpose()) ** 2
-                        )
+                        varExpl[0, i] = np.mean(np.corrcoef(pcx, datModule.transpose()) ** 2)
                         pc = pcx
                     except:
                         check = False
             if not check:
                 if not trapErrors:
                     sys.exit("Error!")
-                print(
-                    " ..ME calculation of module",
-                    modulename,
-                    "failed with the following error:",
-                    flush=True,
-                )
-                print(
-                    "     ", pc, " ..the offending module has been removed.", flush=True
-                )
+                print(" ..ME calculation of module", modulename, "failed with the following error:", flush=True)
+                print("     ", pc, " ..the offending module has been removed.", flush=True)
                 print(
                     f"{WARNING}Eigengene calculation of module {modulename} failed with the following error \n"
-                    f"{pc} The offending module has been removed.{ENDC}"
-                )
+                    f"{pc} The offending module has been removed.{ENDC}")
                 validMEs[i] = False
                 isPC[i] = False
                 isHub[i] = False
@@ -2629,9 +2087,7 @@ class WGCNA(GeneExp):
                         scaledExpr = scale(datModule.T)
                     averExpr.iloc[:, i] = scaledExpr.mean(axis=1)
                     if align == "along average":
-                        corAve = np.corrcoef(averExpr.iloc[:, i], PrinComps.iloc[:, i])[
-                            0, 1
-                        ]
+                        corAve = np.corrcoef(averExpr.iloc[:, i], PrinComps.iloc[:, i])[0, 1]
                         if not np.isfinite(corAve):
                             corAve = 0
                         if corAve < 0:
@@ -2640,24 +2096,15 @@ class WGCNA(GeneExp):
                 except:
                     if not trapErrors:
                         sys.exit("Error!")
-                    print(
-                        " ..Average expression calculation of module",
-                        modulename,
-                        "failed with the following error:",
-                        flush=True,
-                    )
-                    print(
-                        " ..the returned average expression vector will be invalid.",
-                        flush=True,
-                    )
+                    print(" ..Average expression calculation of module", modulename,
+                          "failed with the following error:", flush=True)
+                    print(" ..the returned average expression vector will be invalid.", flush=True)
 
-                    print(
-                        f"{WARNING}Average expression calculation of module {modulename} "
-                        f"failed with the following error.\nThe returned average expression vector will "
-                        f"be invalid.\n{ENDC}"
-                    )
+                    print(f"{WARNING}Average expression calculation of module {modulename} "
+                          f"failed with the following error.\nThe returned average expression vector will "
+                          f"be invalid.\n{ENDC}")
 
-        allOK = sum(np.logical_not(validMEs)) == 0
+        allOK = (sum(np.logical_not(validMEs)) == 0)
         if returnValidOnly and sum(np.logical_not(validMEs)) > 0:
             PrinComps = PrinComps[:, validMEs]
             averExpr = averExpr[:, validMEs]
@@ -2667,25 +2114,14 @@ class WGCNA(GeneExp):
             isHub = isHub[validMEs]
             validAEs = validAEs[validMEs]
 
-        allPC = sum(np.logical_not(isPC)) == 0
-        allAEOK = sum(np.logical_not(validAEs)) == 0
+        allPC = (sum(np.logical_not(isPC)) == 0)
+        allAEOK = (sum(np.logical_not(validAEs)) == 0)
 
         print("\tDone..\n")
 
-        return {
-            "eigengenes": PrinComps,
-            "averageExpr": averExpr,
-            "varExplained": varExpl,
-            "nPC": nPC,
-            "validMEs": validMEs,
-            "validColors": validColors,
-            "allOK": allOK,
-            "allPC": allPC,
-            "isPC": isPC,
-            "isHub": isHub,
-            "validAEs": validAEs,
-            "allAEOK": allAEOK,
-        }
+        return {"eigengenes": PrinComps, "averageExpr": averExpr, "varExplained": varExpl, "nPC": nPC,
+                "validMEs": validMEs, "validColors": validColors, "allOK": allOK, "allPC": allPC, "isPC": isPC,
+                "isHub": isHub, "validAEs": validAEs, "allAEOK": allAEOK}
 
     @staticmethod
     def permissiveDim(x):
@@ -2724,22 +2160,18 @@ class WGCNA(GeneExp):
                 nGenes = 0
                 nSamples = 0
             else:
-                sys.exit(
-                    "data does not appear to have the correct format. "
-                    "Consider using fixDataStructure or setting checkStructure = TRUE when calling this function."
-                )
+                sys.exit("data does not appear to have the correct format. "
+                         "Consider using fixDataStructure or setting checkStructure = TRUE when calling this function.")
         elif isinstance(data, dict):
             nSamples = np.zeros(nSets)
-            nGenes = WGCNA.permissiveDim(data[useSets[0]]["data"])[1]
+            nGenes = WGCNA.permissiveDim(data[useSets[0]]['data'])[1]
             for set in useSets:
-                if nGenes != WGCNA.permissiveDim(data[set]["data"])[1]:
+                if nGenes != WGCNA.permissiveDim(data[set]['data'])[1]:
                     if checkStructure:
                         structureOK = False
                     else:
-                        sys.exit(
-                            ("Incompatible number of genes in set 1 and", str(set))
-                        )
-                nSamples[set] = WGCNA.permissiveDim(data[set]["data"])[0]
+                        sys.exit(("Incompatible number of genes in set 1 and", str(set)))
+                nSamples[set] = WGCNA.permissiveDim(data[set]['data'])[0]
         else:
             nSamples = np.zeros(nSets)
             nGenes = WGCNA.permissiveDim(data[useSets[0]])[1]
@@ -2748,16 +2180,9 @@ class WGCNA(GeneExp):
                     if checkStructure:
                         structureOK = False
                     else:
-                        sys.exit(
-                            ("Incompatible number of genes in set 1 and", str(set))
-                        )
+                        sys.exit(("Incompatible number of genes in set 1 and", str(set)))
                 nSamples[set] = WGCNA.permissiveDim(data[set])[0]
-        return {
-            "nSets": nSets,
-            "nGenes": nGenes,
-            "nSamples": nSamples,
-            "structureOK": structureOK,
-        }
+        return {"nSets": nSets, "nGenes": nGenes, "nSamples": nSamples, "structureOK": structureOK}
 
     @staticmethod
     def fixDataStructure(data):
@@ -2773,25 +2198,13 @@ class WGCNA(GeneExp):
         if not isinstance(data, list):
             print("fixDataStructure: data is not a Dictionary: converting it into one.")
             x = data.copy()
-            data = {0: {"data": x}}
+            data = {0: {'data': x}}
         return data
 
     @staticmethod
-    def multiSetMEs(
-        exprData,
-        colors,
-        universalColors=None,
-        useSets=None,
-        useGenes=None,
-        impute=True,
-        nPC=1,
-        align="along average",
-        excludeGrey=False,
-        subHubs=True,
-        trapErrors=False,
-        softPower=6,
-        grey=None,
-    ):
+    def multiSetMEs(exprData, colors, universalColors=None, useSets=None, useGenes=None, impute=True, nPC=1,
+                    align="along average", excludeGrey=False, subHubs=True, trapErrors=False, softPower=6,
+                    grey=None):
         """
         Calculates module eigengenes for several sets.
 
@@ -2838,8 +2251,8 @@ class WGCNA(GeneExp):
                 grey = "grey"
         nSets = len(exprData)
         setsize = WGCNA.checkSets(exprData, useSets=useSets)
-        nGenes = setsize["nGenes"]
-        nSamples = setsize["nSamples"]
+        nGenes = setsize['nGenes']
+        nSamples = setsize['nSamples']
         print("multiSetMEs: Calculating module MEs.", flush=True)
         MEs = {}
         consValidMEs = None
@@ -2854,27 +2267,17 @@ class WGCNA(GeneExp):
                     setColors = colors[:, set]
                 else:
                     setColors = universalColors
-                setMEs = WGCNA.moduleEigengenes(
-                    expr=exprData[set],
-                    colors=setColors,
-                    impute=impute,
-                    nPC=nPC,
-                    align=align,
-                    excludeGrey=excludeGrey,
-                    grey=grey,
-                    trapErrors=trapErrors,
-                    subHubs=subHubs,
-                    softPower=softPower,
-                )
-                if universalColors is not None and not setMEs["allOK"]:
+                setMEs = WGCNA.moduleEigengenes(expr=exprData[set], colors=setColors, impute=impute, nPC=nPC,
+                                                align=align, excludeGrey=excludeGrey, grey=grey, trapErrors=trapErrors,
+                                                subHubs=subHubs, softPower=softPower)
+                if universalColors is not None and not setMEs['allOK']:
                     if consValidMEs is None:
-                        consValidMEs = setMEs["validMEs"]
+                        consValidMEs = setMEs['validMEs']
                     else:
-                        consValidMEs = consValidMEs * setMEs["validMEs"]
-                    consValidColors[setMEs["validColors"] != universalColors] = setMEs[
-                        "validColors"
-                    ][setMEs["validColors"] != universalColors]
-                setMEs["data"] = setMEs.pop("eigengenes")
+                        consValidMEs = consValidMEs * setMEs['validMEs']
+                    consValidColors[setMEs['validColors'] != universalColors] = setMEs['validColors'][
+                        setMEs['validColors'] != universalColors]
+                setMEs['data'] = setMEs.pop("eigengenes")
                 MEs[set] = setMEs
         else:
             for set in useSets:
@@ -2883,95 +2286,73 @@ class WGCNA(GeneExp):
                     setColors = colors[useGenes, set]
                 else:
                     setColors = universalColors[useGenes]
-                setMEs = WGCNA.moduleEigengenes(
-                    expr=exprData[[set]][:, useGenes],
-                    colors=setColors,
-                    impute=impute,
-                    nPC=nPC,
-                    align=align,
-                    excludeGrey=excludeGrey,
-                    grey=grey,
-                    trapErrors=trapErrors,
-                    subHubs=subHubs,
-                    softPower=softPower,
-                )
-                if universalColors is not None and not setMEs["allOK"]:
+                setMEs = WGCNA.moduleEigengenes(expr=exprData[[set]][:, useGenes], colors=setColors, impute=impute,
+                                                nPC=nPC, align=align, excludeGrey=excludeGrey, grey=grey,
+                                                trapErrors=trapErrors, subHubs=subHubs, softPower=softPower)
+                if universalColors is not None and not setMEs['allOK']:
                     if consValidMEs is None:
-                        consValidMEs = setMEs["validMEs"]
+                        consValidMEs = setMEs['validMEs']
                     else:
-                        consValidMEs = consValidMEs * setMEs["validMEs"]
-                    consValidColors[
-                        setMEs["validColors"] != universalColors[useGenes]
-                    ] = setMEs["validColors"][
-                        setMEs["validColors"] != universalColors[useGenes]
-                    ]
-                setMEs["data"] = setMEs.pop("eigengenes")
+                        consValidMEs = consValidMEs * setMEs['validMEs']
+                    consValidColors[setMEs['validColors'] != universalColors[useGenes]] = \
+                        setMEs['validColors'][setMEs['validColors'] != universalColors[useGenes]]
+                setMEs['data'] = setMEs.pop("eigengenes")
                 MEs[set] = setMEs
         if universalColors is not None:
             for set in range(nSets):
                 if consValidMEs is not None:
-                    MEs[set]["validMEs"] = consValidMEs
-                MEs[set]["validColors"] = consValidColors
+                    MEs[set]['validMEs'] = consValidMEs
+                MEs[set]['validColors'] = consValidColors
         for set in range(nSets):
-            MEs[set]["allOK"] = sum(np.logical_not(MEs[set]["validMEs"])) == 0
+            MEs[set]['allOK'] = (sum(np.logical_not(MEs[set]['validMEs'])) == 0)
             if returnValidOnly:
-                valid = MEs[set]["validMEs"] > 0
-                MEs[set]["data"] = MEs[set]["data"][:, valid]
-                MEs[set]["averageExpr"] = MEs[set]["averageExpr"][:, valid]
-                MEs[set]["varExplained"] = MEs[set]["varExplained"][:, valid]
-                MEs[set]["isPC"] = MEs[set]["isPC"][valid]
-                MEs[set]["allPC"] = sum(np.logical_not(MEs[set]["isPC"])) == 0
-                MEs[set]["isHub"] = MEs[set]["isHub"][valid]
-                MEs[set]["validAEs"] = MEs[set]["validAEs"][valid]
-                MEs[set]["allAEOK"] = sum(np.logical_not(MEs[set]["validAEs"])) == 0
-                MEs[set]["validMEs"] = np.repeat(True, MEs[set]["data"].shape[1])
+                valid = (MEs[set]['validMEs'] > 0)
+                MEs[set]['data'] = MEs[set]['data'][:, valid]
+                MEs[set]['averageExpr'] = MEs[set]['averageExpr'][:, valid]
+                MEs[set]['varExplained'] = MEs[set]['varExplained'][:, valid]
+                MEs[set]['isPC'] = MEs[set]['isPC'][valid]
+                MEs[set]['allPC'] = (sum(np.logical_not(MEs[set]['isPC'])) == 0)
+                MEs[set]['isHub'] = MEs[set]['isHub'][valid]
+                MEs[set]['validAEs'] = MEs[set]['validAEs'][valid]
+                MEs[set]['allAEOK'] = (sum(np.logical_not(MEs[set]['validAEs'])) == 0)
+                MEs[set]['validMEs'] = np.repeat(True, MEs[set]['data'].shape[1])
         # names(MEs) = names(exprData)
         return MEs
 
     @staticmethod
-    def consensusMEDissimilarityMajor(
-        MEs, useAbs=False, useSets=None, method="consensus"
-    ):
+    def consensusMEDissimilarityMajor(MEs, useAbs=False, useSets=None, method="consensus"):
         """
         Calculates consensus dissimilarity (1-cor) of given module eigengenes realized in several sets.
         """
         methods = ["consensus", "majority"]
         m = methods.index(method)
         if m is None:
-            sys.exit(
-                f"Unrecognized method given. Recognized values are {', '.join(methods)}"
-            )
+            sys.exit(f"Unrecognized method given. Recognized values are {', '.join(methods)}")
         nSets = len(MEs)
         MEDiss = {}
         if useSets is None:
             useSets = list(range(nSets))
         for set in useSets:
             if useAbs:
-                diss = 1 - np.abs(np.corrcoef(MEs[set]["data"], rowvar=False))
+                diss = 1 - np.abs(np.corrcoef(MEs[set]['data'], rowvar=False))
             else:
-                diss = 1 - np.corrcoef(MEs[set]["data"], rowvar=False)
-            diss = pd.DataFrame(
-                diss, index=MEs[set]["data"].columns, columns=MEs[set]["data"].columns
-            )
+                diss = 1 - np.corrcoef(MEs[set]['data'], rowvar=False)
+            diss = pd.DataFrame(diss, index=MEs[set]['data'].columns, columns=MEs[set]['data'].columns)
             MEDiss[set] = {}
-            MEDiss[set]["Diss"] = diss
+            MEDiss[set]['Diss'] = diss
         for set in useSets:
             if set == useSets[0]:
-                ConsDiss = MEDiss[set]["Diss"]
+                ConsDiss = MEDiss[set]['Diss']
             else:
                 if m == 0:
-                    ConsDiss = pd.concat([ConsDiss, MEDiss[set]["Diss"]]).max(
-                        level=0
-                    )  # pmax(ConsDiss, MEDiss[[set]]['Diss'])
+                    ConsDiss = pd.concat([ConsDiss, MEDiss[set]['Diss']]).max(
+                        level=0)  # pmax(ConsDiss, MEDiss[[set]]['Diss'])
                 else:
-                    ConsDiss = ConsDiss + MEDiss[set]["Diss"]
+                    ConsDiss = ConsDiss + MEDiss[set]['Diss']
         if m == 1:
             ConsDiss = ConsDiss / nSets
-        ConsDiss = pd.DataFrame(
-            ConsDiss,
-            index=np.unique(MEs[useSets[0]]["data"].columns),
-            columns=MEs[useSets[0]]["data"].columns,
-        )
+        ConsDiss = pd.DataFrame(ConsDiss, index=np.unique(MEs[useSets[0]]['data'].columns),
+                                columns=MEs[useSets[0]]['data'].columns)
 
         return ConsDiss
 
@@ -2987,10 +2368,8 @@ class WGCNA(GeneExp):
         if greyLast and greyInd is not None:
             clusterMEs = np.where(greyName != distNames)[0].tolist()
             if len(clusterMEs) > 1:
-                h = WGCNA.hclust(
-                    pdist(distM.iloc[clusterMEs, clusterMEs]), method="average"
-                )
-                order = dendrogram(h, no_plot=True)["leaves"]  # order
+                h = WGCNA.hclust(pdist(distM.iloc[clusterMEs, clusterMEs]), method="average")
+                order = dendrogram(h, no_plot=True)['leaves']  # order
                 if len(np.where(np.array(order) >= greyInd)[0].tolist()) > 0:
                     for x in np.where(np.array(order) >= greyInd)[0].tolist():
                         order[x] = order[x] + 1
@@ -3005,15 +2384,13 @@ class WGCNA(GeneExp):
         else:
             if len(distM) > 1:
                 h = WGCNA.hclust(pdist(distM), method="average")
-                order = dendrogram(h, no_plot=True)["leaves"]  # order
+                order = dendrogram(h, no_plot=True)['leaves']  # order
             else:
                 order = 1
         return order
 
     @staticmethod
-    def orderMEs(
-        MEs, greyLast=True, greyName="MEgrey", orderBy=0, order=None, useSets=None
-    ):
+    def orderMEs(MEs, greyLast=True, greyName="MEgrey", orderBy=0, order=None, useSets=None):
         """
         Reorder given (eigen-)vectors such that similar ones (as measured by correlation) are next to each other.
 
@@ -3035,34 +2412,26 @@ class WGCNA(GeneExp):
         """
         if "eigengenes" in MEs.keys():
             if order is None:
-                print(
-                    "orderMEs: order not given, calculating using given set",
-                    str(orderBy),
-                    flush=True,
-                )
-                disPC = 1 - np.corrcoef(MEs["eigengenes"], rowvar=False)
-                disPC = pd.DataFrame(
-                    disPC,
-                    index=MEs["eigengenes"].index,
-                    columns=MEs["eigengenes"].index,
-                )
+                print("orderMEs: order not given, calculating using given set", str(orderBy), flush=True)
+                disPC = 1 - np.corrcoef(MEs['eigengenes'], rowvar=False)
+                disPC = pd.DataFrame(disPC, index=MEs['eigengenes'].index, columns=MEs['eigengenes'].index)
                 order = WGCNA.clustOrder(disPC, greyLast=greyLast, greyName=greyName)
-            if len(order) != MEs["eigengenes"].shape[1]:
+            if len(order) != MEs['eigengenes'].shape[1]:
                 sys.exit("orderMEs: given MEs and order have incompatible dimensions.")
             orderedMEs = MEs.copy()
-            orderedMEs["eigengenes"] = pd.DataFrame(MEs["eigengenes"][:, order])
-            orderedMEs["eigengenes"].columns = MEs["eigengenes"].columns[order]
-            if MEs["averageExpr"] is not None:
-                orderedMEs["averageExpr"] = pd.DataFrame(MEs["averageExpr"][:, order])
-                orderedMEs["averageExpr"].columns = MEs["eigengenes"].columns[order]
+            orderedMEs['eigengenes'] = pd.DataFrame(MEs['eigengenes'][:, order])
+            orderedMEs['eigengenes'].columns = MEs['eigengenes'].columns[order]
+            if MEs['averageExpr'] is not None:
+                orderedMEs['averageExpr'] = pd.DataFrame(MEs['averageExpr'][:, order])
+                orderedMEs['averageExpr'].columns = MEs['eigengenes'].columns[order]
 
-            if MEs["varExplained"] is not None:
-                orderedMEs["varExplained"] = pd.DataFrame(MEs["varExplained"][:, order])
-                orderedMEs["varExplained"].columns = MEs["eigengenes"].columns[order]
+            if MEs['varExplained'] is not None:
+                orderedMEs['varExplained'] = pd.DataFrame(MEs['varExplained'][:, order])
+                orderedMEs['varExplained'].columns = MEs['eigengenes'].columns[order]
             return orderedMEs
         else:
             check = WGCNA.checkSets(MEs, checkStructure=True, useSets=useSets)
-            if check["structureOK"]:
+            if check['structureOK']:
                 multiSet = True
             else:
                 multiSet = False
@@ -3073,50 +2442,31 @@ class WGCNA(GeneExp):
                 if useSets.index(orderBy) is None:
                     orderBy = useSets[1]
             if order is None:
-                print(
-                    "orderMEs: order not given, calculating using given set",
-                    str(orderBy),
-                    flush=True,
-                )
-                disPC = 1 - np.corrcoef(MEs[orderBy]["data"], rowvar=False)
-                disPC = pd.DataFrame(
-                    disPC,
-                    index=MEs[orderBy]["data"].columns,
-                    columns=MEs[orderBy]["data"].columns,
-                )
+                print("orderMEs: order not given, calculating using given set", str(orderBy), flush=True)
+                disPC = 1 - np.corrcoef(MEs[orderBy]['data'], rowvar=False)
+                disPC = pd.DataFrame(disPC, index=MEs[orderBy]['data'].columns, columns=MEs[orderBy]['data'].columns)
                 order = WGCNA.clustOrder(disPC, greyLast=greyLast, greyName=greyName)
-            if len(order) != MEs[orderBy]["data"].shape[1]:
+            if len(order) != MEs[orderBy]['data'].shape[1]:
                 sys.exit("orderMEs: given MEs and order have incompatible dimensions.")
             nSets = len(MEs)
             orderedMEs = MEs.copy()
             if useSets is None:
                 useSets = list(range(nSets))
             for set in useSets:
-                orderedMEs[set]["data"] = MEs[set]["data"].iloc[:, order]
+                orderedMEs[set]['data'] = MEs[set]['data'].iloc[:, order]
                 if "averageExpr" in MEs[set].keys():
-                    if MEs[set]["averageExpr"] is not None:
-                        orderedMEs[set]["averageExpr"] = MEs[set]["averageExpr"].iloc[
-                            :, order
-                        ]
+                    if MEs[set]['averageExpr'] is not None:
+                        orderedMEs[set]['averageExpr'] = MEs[set]['averageExpr'].iloc[:, order]
                 if "varExplained" in MEs[set].keys():
-                    if MEs[set]["varExplained"] is not None:
-                        orderedMEs[set]["varExplained"] = MEs[set]["varExplained"].iloc[
-                            :, order
-                        ]
+                    if MEs[set]['varExplained'] is not None:
+                        orderedMEs[set]['varExplained'] = MEs[set]['varExplained'].iloc[:, order]
             if multiSet:
                 return orderedMEs
             else:
-                return orderedMEs[0]["data"]
+                return orderedMEs[0]['data']
 
     @staticmethod
-    def consensusOrderMEs(
-        MEs,
-        useAbs=False,
-        useSets=None,
-        greyLast=True,
-        greyName="MEgrey",
-        method="consensus",
-    ):
+    def consensusOrderMEs(MEs, useAbs=False, useSets=None, greyLast=True, greyName="MEgrey", method="consensus"):
         """
         Reorder given (eigen-)vectors such that similar ones (as measured by correlation) are next to each other.
 
@@ -3136,13 +2486,9 @@ class WGCNA(GeneExp):
         :return: A dictionary of the same type as MEs containing the re-ordered eigengenes
         :rtype: dict
         """
-        Diss = WGCNA.consensusMEDissimilarityMajor(
-            MEs, useAbs=useAbs, useSets=useSets, method=method
-        )
+        Diss = WGCNA.consensusMEDissimilarityMajor(MEs, useAbs=useAbs, useSets=useSets, method=method)
         order = WGCNA.clustOrder(Diss, greyLast, greyName)
-        MEs = WGCNA.orderMEs(
-            MEs, greyLast=greyLast, greyName=greyName, order=order, useSets=useSets
-        )
+        MEs = WGCNA.orderMEs(MEs, greyLast=greyLast, greyName=greyName, order=order, useSets=useSets)
         return MEs
 
     @staticmethod
@@ -3160,19 +2506,11 @@ class WGCNA(GeneExp):
         return out
 
     @staticmethod
-    def consensusMEDissimilarity(
-        multiMEs,
-        useSets=None,
-        equalizeQuantiles=False,
-        quantileSummary="mean",
-        corOptions={},
-        consensusQuantile=0,
-        useAbs=False,
-        greyName="ME0",
-    ):
-        nSets = WGCNA.checkSets(multiMEs)["nSets"]
-        useMEs = np.where(multiMEs[0]["data"].columns != greyName)[0].tolist()
-        useNames = multiMEs[0]["data"].columns[useMEs]
+    def consensusMEDissimilarity(multiMEs, useSets=None, equalizeQuantiles=False, quantileSummary="mean",
+                                 corOptions={}, consensusQuantile=0, useAbs=False, greyName="ME0"):
+        nSets = WGCNA.checkSets(multiMEs)['nSets']
+        useMEs = np.where(multiMEs[0]['data'].columns != greyName)[0].tolist()
+        useNames = multiMEs[0]['data'].columns[useMEs]
         nUseMEs = len(useMEs)
         if useSets is None:
             useSets = list(range(nSets))
@@ -3180,14 +2518,12 @@ class WGCNA(GeneExp):
         MEDiss = np.zeros((nUseMEs, nUseMEs, nUseSets))
         MEDiss[:, :, :] = np.nan
         for set in useSets:
-            corOptions["x"] = multiMEs[set]["data"].iloc[:, useMEs]
+            corOptions['x'] = multiMEs[set]['data'].iloc[:, useMEs]
             if useAbs:
-                diss = 1 - np.abs(np.corrcoef(corOptions["x"], rowvar=False))
+                diss = 1 - np.abs(np.corrcoef(corOptions['x'], rowvar=False))
             else:
-                diss = 1 - np.corrcoef(corOptions["x"], rowvar=False)
-            diss = pd.DataFrame(
-                diss, index=corOptions["x"].columns, columns=corOptions["x"].columns
-            )
+                diss = 1 - np.corrcoef(corOptions['x'], rowvar=False)
+            diss = pd.DataFrame(diss, index=corOptions['x'].columns, columns=corOptions['x'].columns)
             MEDiss[:, :, set] = diss
         if equalizeQuantiles:
             distMat = pd.DataFrame()
@@ -3195,17 +2531,12 @@ class WGCNA(GeneExp):
                 distMat[i] = pdist(MEDiss[:, :, i])
             # distMat = apply(MEDiss, 3, function(x) { as.numeric( as.dist(x))})
             # TODO: checkdistMat.shape = [nUseMEs * (nUseMEs - 1) / 2, nUseSets]
-            normalized = WGCNA.equalizeQuantilesFun(
-                distMat, summaryType=quantileSummary
-            )
+            normalized = WGCNA.equalizeQuantilesFun(distMat, summaryType=quantileSummary)
             # TODO:apply(normalized, 2, .turnDistVectorIntoMatrix, size = nUseMEs, Diag = FALSE, Upper = FALSE, diagValue = 0)
             MEDiss = normalized
             np.fill_diagonal(normalized, 0)
-        ConsDiss = pd.DataFrame(
-            np.quantile(MEDiss, q=1 - consensusQuantile, axis=2),
-            index=useNames.unique(),
-            columns=useNames.unique(),
-        )
+        ConsDiss = pd.DataFrame(np.quantile(MEDiss, q=1 - consensusQuantile, axis=2), index=useNames.unique(),
+                                columns=useNames.unique())
         return ConsDiss
 
     @staticmethod
@@ -3214,32 +2545,14 @@ class WGCNA(GeneExp):
         NOnBranches = pd.DataFrame(Branches).value_counts()
         TrueBranch = NOnBranches >= minSize
         if len(np.where(np.logical_not(TrueBranch.iloc[Branches]))[0].tolist()) != 0:
-            Branches[
-                np.where(np.logical_not(TrueBranch.iloc[Branches]))[0].tolist()
-            ] = 0
+            Branches[np.where(np.logical_not(TrueBranch.iloc[Branches]))[0].tolist()] = 0
         return Branches
 
     @staticmethod
-    def mergeCloseModules(
-        exprData,
-        colors,
-        MEs=None,
-        useSets=None,
-        impute=True,
-        checkDataFormat=True,
-        unassdColor="grey",
-        useAbs=False,
-        equalizeQuantiles=False,
-        quantileSummary="mean",
-        consensusQuantile=0,
-        cutHeight=0.2,
-        iterate=True,
-        relabel=False,
-        colorSeq=None,
-        getNewMEs=True,
-        getNewUnassdME=True,
-        trapErrors=False,
-    ):
+    def mergeCloseModules(exprData, colors, MEs=None, useSets=None, impute=True, checkDataFormat=True,
+                          unassdColor="grey", useAbs=False, equalizeQuantiles=False, quantileSummary="mean",
+                          consensusQuantile=0, cutHeight=0.2, iterate=True, relabel=False, colorSeq=None,
+                          getNewMEs=True, getNewUnassdME=True, trapErrors=False):
         """
         Merges modules in gene expression networks that are too close as measured by the correlation of their eigengenes.
 
@@ -3288,100 +2601,57 @@ class WGCNA(GeneExp):
         MEsInSingleFrame = False
         origColors = colors
         greyName = "ME" + unassdColor
-        print(
-            "mergeCloseModules: Merging modules whose distance is less than",
-            str(cutHeight),
-            flush=True,
-        )
-        if not WGCNA.checkSets(exprData, checkStructure=True, useSets=useSets)[
-            "structureOK"
-        ]:
+        print("mergeCloseModules: Merging modules whose distance is less than", str(cutHeight), flush=True)
+        if not WGCNA.checkSets(exprData, checkStructure=True, useSets=useSets)['structureOK']:
             if checkDataFormat:
                 exprData = WGCNA.fixDataStructure(exprData)
                 MEsInSingleFrame = True
             else:
                 sys.exit("Given exprData appear to be misformatted.")
         setsize = WGCNA.checkSets(exprData, useSets=useSets)
-        nSets = setsize["nSets"]
+        nSets = setsize['nSets']
         if MEs is not None:
             checkMEs = WGCNA.checkSets(MEs, checkStructure=True, useSets=useSets)
-            if checkMEs["structureOK"]:
-                if setsize["nSets"] != checkMEs["nSets"]:
+            if checkMEs['structureOK']:
+                if setsize['nSets'] != checkMEs['nSets']:
                     sys.exit("Input error: numbers of sets in exprData and MEs differ.")
                 for set in range(nSets):
-                    if checkMEs["nSamples"][set] != setsize["nSamples"][set]:
-                        sys.exit(
-                            (
-                                "Number of samples in MEs is incompatible with subset length for set",
-                                str(set),
-                            )
-                        )
+                    if checkMEs['nSamples'][set] != setsize['nSamples'][set]:
+                        sys.exit(("Number of samples in MEs is incompatible with subset length for set", str(set)))
             else:
                 if MEsInSingleFrame:
                     MEs = WGCNA.fixDataStructure(MEs)
                     checkMEs = WGCNA.checkSets(MEs)
                 else:
-                    sys.exit(
-                        "MEs do not have the appropriate structure (same as exprData). "
-                    )
-        if setsize["nGenes"] != len(colors):
-            sys.exit(
-                "Number of genes in exprData is different from the length of original colors. They must equal."
-            )
+                    sys.exit("MEs do not have the appropriate structure (same as exprData). ")
+        if setsize['nGenes'] != len(colors):
+            sys.exit("Number of genes in exprData is different from the length of original colors. They must equal.")
         if cutHeight < 0 or cutHeight > 1 + int(useAbs):
-            sys.exit(
-                (
-                    "Given cutHeight is out of sensible range between 0 and",
-                    1 + int(useAbs),
-                )
-            )
+            sys.exit(("Given cutHeight is out of sensible range between 0 and", 1 + int(useAbs)))
         done = False
         iteration = 1
         MergedColors = colors
         try:
             while not done:
                 if MEs is None:
-                    MEs = WGCNA.multiSetMEs(
-                        exprData,
-                        colors=None,
-                        universalColors=colors,
-                        useSets=useSets,
-                        impute=impute,
-                        subHubs=True,
-                        trapErrors=False,
-                        excludeGrey=True,
-                        grey=unassdColor,
-                    )
-                    MEs = WGCNA.consensusOrderMEs(
-                        MEs, useAbs=useAbs, useSets=useSets, greyLast=False
-                    )
-                elif len(pd.Categorical(colors).codes) != checkMEs["nGenes"]:
+                    MEs = WGCNA.multiSetMEs(exprData, colors=None, universalColors=colors, useSets=useSets,
+                                            impute=impute, subHubs=True, trapErrors=False, excludeGrey=True,
+                                            grey=unassdColor)
+                    MEs = WGCNA.consensusOrderMEs(MEs, useAbs=useAbs, useSets=useSets, greyLast=False)
+                elif len(pd.Categorical(colors).codes) != checkMEs['nGenes']:
                     if iteration == 1:
                         print(
                             "Number of given module colors does not match number of given MEs => recalculating the MEs.",
-                            flush=True,
-                        )
-                    MEs = WGCNA.multiSetMEs(
-                        exprData,
-                        colors=None,
-                        universalColors=colors,
-                        useSets=useSets,
-                        impute=impute,
-                        subHubs=True,
-                        trapErrors=False,
-                        excludeGrey=True,
-                        grey=unassdColor,
-                    )
-                    MEs = WGCNA.consensusOrderMEs(
-                        MEs, useAbs=useAbs, useSets=useSets, greyLast=False
-                    )
+                            flush=True)
+                    MEs = WGCNA.multiSetMEs(exprData, colors=None, universalColors=colors, useSets=useSets,
+                                            impute=impute, subHubs=True, trapErrors=False, excludeGrey=True,
+                                            grey=unassdColor)
+                    MEs = WGCNA.consensusOrderMEs(MEs, useAbs=useAbs, useSets=useSets, greyLast=False)
                 if iteration == 1:
                     oldMEs = MEs
                 colLevs = pd.Categorical(colors)
                 if len(colLevs[colLevs != str(unassdColor)]) < 2:
-                    print(
-                        "mergeCloseModules: less than two proper modules.", flush=True
-                    )
+                    print("mergeCloseModules: less than two proper modules.", flush=True)
                     print(" ..color levels are", colLevs, flush=True)
                     print(" ..there is nothing to merge.", flush=True)
                     MergedNewColors = colors
@@ -3392,15 +2662,10 @@ class WGCNA(GeneExp):
                     Tree = None
                     break
                 nOldMods = len(pd.Categorical(colors).categories)
-                ConsDiss = WGCNA.consensusMEDissimilarity(
-                    MEs,
-                    equalizeQuantiles=equalizeQuantiles,
-                    quantileSummary=quantileSummary,
-                    consensusQuantile=consensusQuantile,
-                    useAbs=useAbs,
-                    useSets=useSets,
-                    greyName=greyName,
-                )
+                ConsDiss = WGCNA.consensusMEDissimilarity(MEs, equalizeQuantiles=equalizeQuantiles,
+                                                          quantileSummary=quantileSummary,
+                                                          consensusQuantile=consensusQuantile, useAbs=useAbs,
+                                                          useSets=useSets, greyName=greyName)
                 a = squareform(ConsDiss, checks=False)
                 Tree = WGCNA.hclust(a, method="average")
                 if iteration == 1:
@@ -3414,15 +2679,12 @@ class WGCNA(GeneExp):
                 for branch in range(nBranches):
                     if NumberOnBranch[branch] > 1:
                         ModulesOnThisBranch = TreeBranches.columns[
-                            np.where(TreeBranches == UniqueBranches[branch])[1].tolist()
-                        ]
+                            np.where(TreeBranches == UniqueBranches[branch])[1].tolist()]
                         ColorsOnThisBranch = [x[2:] for x in ModulesOnThisBranch]
                         if all(isinstance(x, int) for x in origColors):
                             ColorsOnThisBranch = [int(x) for x in ColorsOnThisBranch]
                         for color in range(1, len(ColorsOnThisBranch)):
-                            MergedColors[MergedColors == ColorsOnThisBranch[color]] = (
-                                ColorsOnThisBranch[0]
-                            )
+                            MergedColors[MergedColors == ColorsOnThisBranch[color]] = ColorsOnThisBranch[0]
                 # MergedColors = MergedColors[:, drop = TRUE]
                 nNewMods = len(pd.Categorical(MergedColors).categories)
                 if nNewMods < nOldMods and iterate:
@@ -3435,16 +2697,12 @@ class WGCNA(GeneExp):
                 RawModuleColors = pd.Categorical(MergedColors).codes
                 if colorSeq is None:
                     if isinstance(int, origColors):
-                        colorSeq = list(
-                            range(len(pd.DataFrame(origColors).value_counts()))
-                        )
+                        colorSeq = list(range(len(pd.DataFrame(origColors).value_counts())))
                     else:
                         nNewColors = len(RawModuleColors)
                         colorSeq = WGCNA.labels2colors(list(range(nNewColors)))
                 nGenesInModule = pd.DataFrame(MergedColors).value_counts()
-                SortedRawModuleColors = RawModuleColors[
-                    nGenesInModule.sort(reverse=True)
-                ]
+                SortedRawModuleColors = RawModuleColors[nGenesInModule.sort(reverse=True)]
                 MergedNewColors = MergedColors
                 if isinstance(pd.Categorical, MergedNewColors):
                     MergedNewColors = str(MergedNewColors)
@@ -3452,9 +2710,7 @@ class WGCNA(GeneExp):
                 for color in range(len(SortedRawModuleColors)):
                     if SortedRawModuleColors[color] != unassdColor:
                         rank = rank + 1
-                        MergedNewColors[
-                            MergedColors == SortedRawModuleColors[color]
-                        ] = colorSeq[rank]
+                        MergedNewColors[MergedColors == SortedRawModuleColors[color]] = colorSeq[rank]
                 if isinstance(pd.Categorical, MergedColors):
                     MergedNewColors = pd.Categorical(MergedNewColors)
             else:
@@ -3463,33 +2719,15 @@ class WGCNA(GeneExp):
             if getNewMEs:
                 if nNewMods < nOldMods or relabel or getNewUnassdME:
                     print("  Calculating new MEs...", flush=True)
-                    NewMEs = WGCNA.multiSetMEs(
-                        exprData,
-                        colors=None,
-                        universalColors=MergedNewColors,
-                        useSets=useSets,
-                        impute=impute,
-                        subHubs=True,
-                        trapErrors=False,
-                        excludeGrey=not getNewUnassdME,
-                        grey=unassdColor,
-                    )
-                    newMEs = WGCNA.consensusOrderMEs(
-                        NewMEs,
-                        useAbs=useAbs,
-                        useSets=useSets,
-                        greyLast=True,
-                        greyName=greyName,
-                    )
-                    ConsDiss = WGCNA.consensusMEDissimilarity(
-                        newMEs,
-                        equalizeQuantiles=equalizeQuantiles,
-                        quantileSummary=quantileSummary,
-                        consensusQuantile=consensusQuantile,
-                        useAbs=useAbs,
-                        useSets=useSets,
-                        greyName=greyName,
-                    )
+                    NewMEs = WGCNA.multiSetMEs(exprData, colors=None, universalColors=MergedNewColors, useSets=useSets,
+                                               impute=impute, subHubs=True, trapErrors=False,
+                                               excludeGrey=not getNewUnassdME, grey=unassdColor)
+                    newMEs = WGCNA.consensusOrderMEs(NewMEs, useAbs=useAbs, useSets=useSets, greyLast=True,
+                                                     greyName=greyName)
+                    ConsDiss = WGCNA.consensusMEDissimilarity(newMEs, equalizeQuantiles=equalizeQuantiles,
+                                                              quantileSummary=quantileSummary,
+                                                              consensusQuantile=consensusQuantile,
+                                                              useAbs=useAbs, useSets=useSets, greyName=greyName)
                     if len(ConsDiss) > 1:
                         Tree = WGCNA.hclust(pdist(ConsDiss), method="average")
                     else:
@@ -3508,19 +2746,11 @@ class WGCNA(GeneExp):
             print(" --> returning unmerged modules and *no* eigengenes.", flush=True)
             print(
                 f"{WARNING}mergeCloseModules: merging of modules failed --> returning unmerged modules and *no* "
-                f"eigengenes.\n{ENDC}"
-            )
+                f"eigengenes.\n{ENDC}")
             return {"colors": origColors, "allOK": False}
         else:
-            return {
-                "colors": MergedNewColors,
-                "dendro": Tree,
-                "oldDendro": oldTree,
-                "cutHeight": cutHeight,
-                "oldMEs": oldMEs["data"],
-                "newMEs": newMEs["data"],
-                "allOK": True,
-            }
+            return {"colors": MergedNewColors, "dendro": Tree, "oldDendro": oldTree, "cutHeight": cutHeight,
+                    "oldMEs": oldMEs['data'], "newMEs": newMEs['data'], "allOK": True}
 
     def saveWGCNA(self):
         """
@@ -3528,7 +2758,7 @@ class WGCNA(GeneExp):
         """
         print(f"{BOLD}{OKBLUE}Saving WGCNA as {self.name}.p{ENDC}")
 
-        picklefile = open(f"{self.outputPath}{self.name}.p", "wb")
+        picklefile = open(f"{self.outputPath}{self.name}.p", 'wb')
         pickle.dump(self, picklefile)
         picklefile.close()
 
@@ -3550,7 +2780,8 @@ class WGCNA(GeneExp):
                 datTraits[data.columns[i]] = data.iloc[:, i]
                 org = np.unique(data.iloc[:, i]).tolist()
                 rep = list(range(len(org)))
-                datTraits.replace(to_replace=org, value=rep, inplace=True)
+                datTraits.replace(to_replace=org, value=rep,
+                                  inplace=True)
             elif len(np.unique(data.iloc[:, i])) > 2:
                 for name in np.unique(data.iloc[:, i]):
                     datTraits[name] = data.iloc[:, i]
@@ -3563,14 +2794,12 @@ class WGCNA(GeneExp):
 
         return datTraits
 
-    def module_trait_relationships_heatmap(
-        self,
-        metaData,
-        alternative="two-sided",
-        figsize=None,
-        show=True,
-        file_name="module-traitRelationships",
-    ):
+    def module_trait_relationships_heatmap(self,
+                                           metaData,
+                                           alternative='two-sided',
+                                           figsize=None,
+                                           show=True,
+                                           file_name='module-traitRelationships'):
         """
         plot topic-trait relationship heatmap
 
@@ -3587,12 +2816,12 @@ class WGCNA(GeneExp):
         """
         datTraits = self.getDatTraits(metaData)
 
-        moduleTraitCor = pd.DataFrame(
-            index=self.MEs.columns, columns=datTraits.columns, dtype="float"
-        )
-        moduleTraitPvalue = pd.DataFrame(
-            index=self.MEs.columns, columns=datTraits.columns, dtype="float"
-        )
+        moduleTraitCor = pd.DataFrame(index=self.MEs.columns,
+                                      columns=datTraits.columns,
+                                      dtype="float")
+        moduleTraitPvalue = pd.DataFrame(index=self.MEs.columns,
+                                         columns=datTraits.columns,
+                                         dtype="float")
 
         for i in self.MEs.columns:
             for j in datTraits.columns:
@@ -3605,68 +2834,39 @@ class WGCNA(GeneExp):
             self.moduleTraitPvalue = moduleTraitPvalue
 
         if figsize is None:
-            figsize = (
-                max(20, int(moduleTraitPvalue.shape[0] * 1.5)),
-                moduleTraitPvalue.shape[1] * 1.5,
-            )
-        fig, ax = plt.subplots(figsize=figsize, facecolor="white")
+            figsize = (max(20, int(moduleTraitPvalue.shape[0] * 1.5)),
+                       moduleTraitPvalue.shape[1] * 1.5)
+        fig, ax = plt.subplots(figsize=figsize, facecolor='white')
         # names
         xlabels = []
         for label in self.MEs.columns:
-            xlabels.append(
-                label[2:].capitalize()
-                + "("
-                + str(sum(self.datExpr.var["moduleColors"] == label[2:]))
-                + ")"
-            )
+            xlabels.append(label[2:].capitalize() + '(' + str(sum(self.datExpr.var['moduleColors'] == label[2:])) + ')')
         ylabels = datTraits.columns
 
         # Loop over data dimensions and create text annotations.
         tmp_cor = moduleTraitCor.T.round(decimals=2)
         tmp_pvalue = moduleTraitPvalue.T.round(decimals=3)
-        labels = (
-            np.asarray(
-                [
-                    "{0}\n({1})".format(cor, pvalue)
-                    for cor, pvalue in zip(
-                        tmp_cor.values.flatten(), tmp_pvalue.values.flatten()
-                    )
-                ]
-            )
-        ).reshape(moduleTraitCor.T.shape)
+        labels = (np.asarray(["{0}\n({1})".format(cor, pvalue)
+                              for cor, pvalue in zip(tmp_cor.values.flatten(),
+                                                     tmp_pvalue.values.flatten())])) \
+            .reshape(moduleTraitCor.T.shape)
 
         sns.set(font_scale=1.5)
-        res = sns.heatmap(
-            moduleTraitCor.T,
-            annot=labels,
-            fmt="",
-            cmap="RdBu_r",
-            vmin=-1,
-            vmax=1,
-            ax=ax,
-            annot_kws={"size": 20, "weight": "bold"},
-            xticklabels=xlabels,
-            yticklabels=ylabels,
-        )
-        res.set_xticklabels(
-            res.get_xmajorticklabels(), fontsize=20, fontweight="bold", rotation=90
-        )
+        res = sns.heatmap(moduleTraitCor.T, annot=labels, fmt="", cmap='RdBu_r',
+                          vmin=-1, vmax=1, ax=ax, annot_kws={'size': 20, "weight": "bold"},
+                          xticklabels=xlabels, yticklabels=ylabels)
+        res.set_xticklabels(res.get_xmajorticklabels(), fontsize=20, fontweight="bold", rotation=90)
         res.set_yticklabels(res.get_ymajorticklabels(), fontsize=20, fontweight="bold")
         plt.yticks(rotation=0)
-        ax.set_title(
-            f"Module-trait Relationships heatmap for {self.name}",
-            fontsize=30,
-            fontweight="bold",
-        )
-        ax.set_facecolor("white")
+        ax.set_title(f"Module-trait Relationships heatmap for {self.name}",
+                     fontsize=30, fontweight="bold")
+        ax.set_facecolor('white')
         fig.tight_layout()
         if not show:
             plt.close(fig)
         if self.save:
-            fig.savefig(
-                f"{self.outputPath}figures/{file_name}.{self.figureType}",
-                bbox_inches="tight",
-            )
+            fig.savefig(f"{self.outputPath}figures/{file_name}.{self.figureType}", \
+                        bbox_inches='tight')
 
     def getModuleName(self):
         """
@@ -3675,7 +2875,7 @@ class WGCNA(GeneExp):
         :return: name of modules
         :rtype: ndarray
         """
-        return np.unique(self.datExpr.var["moduleColors"]).tolist()
+        return np.unique(self.datExpr.var['moduleColors']).tolist()
 
     def getGeneModule(self, moduleName):
         """
@@ -3688,15 +2888,13 @@ class WGCNA(GeneExp):
         :rtype: dict
         """
         output = {}
-        moduleColors = np.unique(self.datExpr.var["moduleColors"]).tolist()
+        moduleColors = np.unique(self.datExpr.var['moduleColors']).tolist()
         if moduleName not in moduleColors:
             print(f"{WARNING}Module name(s) does not exist in {ENDC}")
             return None
         for color in moduleColors:
             if color in moduleName:
-                output[color] = self.datExpr.var[
-                    self.datExpr.var["moduleColors"] == color
-                ]
+                output[color] = self.datExpr.var[self.datExpr.var['moduleColors'] == color]
         return output
 
     def getModulesGene(self, geneIds):
@@ -3714,9 +2912,7 @@ class WGCNA(GeneExp):
 
         modules = []
         for geneId in geneIds:
-            modules.append(
-                self.datExpr.var.moduleColors[self.datExpr.var.gene_id == geneId]
-            )
+            modules.append(self.datExpr.var.moduleColors[self.datExpr.var.gene_id == geneId])
 
         if len(modules) == 1:
             modules = modules[0]
@@ -3759,158 +2955,103 @@ class WGCNA(GeneExp):
                 height_ratios.append(1)
         height_ratios.reverse()
 
-        modules = np.unique(self.datExpr.var["moduleColors"]).tolist()
+        modules = np.unique(self.datExpr.var['moduleColors']).tolist()
         if np.all(moduleName not in modules):
             print(f"{WARNING}Module name does not exist in {ENDC}")
             return None
         else:
-            heatmap = self.datExpr[
-                :, self.datExpr.var["moduleColors"] == moduleName
-            ].to_df()
-            heatmap = (heatmap - heatmap.min(axis=0)) / (
-                heatmap.max(axis=0) - heatmap.min(axis=0)
-            )
+            heatmap = self.datExpr[:, self.datExpr.var['moduleColors'] == moduleName].to_df()
+            heatmap = (heatmap - heatmap.min(axis=0)) / (heatmap.max(axis=0) - heatmap.min(axis=0))
             heatmap = heatmap.T
             a = pdist(heatmap)
             np.nan_to_num(a, copy=False)
             Z = WGCNA.hclust(a, method="average")
             # Clusterize the data
-            labels = fcluster(Z, t=0.8, criterion="distance")
+            labels = fcluster(Z, t=0.8, criterion='distance')
             # Keep the indices to sort labels
             labels_order = np.argsort(labels)
             heatmap = heatmap.iloc[labels_order, :]
-            ME = pd.DataFrame(
-                self.datME["ME" + moduleName].values, columns=["eigengeneExp"]
-            )
-            ME["sample_name"] = self.datME.index
+            ME = pd.DataFrame(self.datME["ME" + moduleName].values, columns=['eigengeneExp'])
+            ME['sample_name'] = self.datME.index
             ind = [i + 0.5 for i in range(ME.shape[0])]
 
             if len(metadata) != 0:
-                fig, axs = plt.subplots(
-                    nrows=3,
-                    ncols=2,
-                    figsize=(ME.shape[0], len(metadata) * 5),
-                    sharex="col",
-                    gridspec_kw={
-                        "height_ratios": [
-                            len(metadata) * 0.4,
-                            len(metadata) * 0.5,
-                            len(metadata) * 1.5,
-                        ],
-                        "width_ratios": [20, 3],
-                    },
-                )
+                fig, axs = plt.subplots(nrows=3, ncols=2, figsize=(ME.shape[0], len(metadata) * 5),
+                                        sharex='col', gridspec_kw={
+                        'height_ratios': [len(metadata) * 0.4, len(metadata) * 0.5, len(metadata) * 1.5],
+                        'width_ratios': [20, 3]})
 
                 gs = axs[0, 1].get_gridspec()
                 # remove the underlying axes
                 for ax in axs[:, 1]:
                     ax.remove()
                 ax_legend = fig.add_subplot(gs[:, 1])
-                ax_legend.axis("off")
-                axs_legend = gridspec.GridSpecFromSubplotSpec(
-                    len(metadata),
-                    1,
-                    subplot_spec=ax_legend.get_subplotspec(),
-                    height_ratios=height_ratios,
-                )
+                ax_legend.axis('off')
+                axs_legend = gridspec.GridSpecFromSubplotSpec(len(metadata), 1,
+                                                              subplot_spec=ax_legend.get_subplotspec(),
+                                                              height_ratios=height_ratios)
 
                 for m in metadata:
                     handles = []
                     x = ind
                     y = np.repeat(3000 * metadata.index(m), len(ind))
-                    color = list(sampleInfo[m].values)
+                    color = sampleInfo[m].values
                     if type(self.metadataColors[m]) == dict:
                         for n in list(self.metadataColors[m].keys()):
-                            color = [
-                                self.metadataColors[m][n] if c == n else c
-                                for c in color
-                            ]
-                            patch = mpatches.Patch(
-                                color=self.metadataColors[m][n], label=n
-                            )
+                            color = np.where(color == n, self.metadataColors[m][n], color)
+                            patch = mpatches.Patch(color=self.metadataColors[m][n], label=n)
                             handles.append(patch)
-                        axs[0, 0].scatter(x, y, c=color, s=1600, marker="s")
-                        ax_legend = plt.Subplot(
-                            fig, axs_legend[len(metadata) - 1 - metadata.index(m)]
-                        )
+                        axs[0, 0].scatter(x, y, c=color, s=1600, marker='s')
+                        ax_legend = plt.Subplot(fig, axs_legend[len(metadata) - 1 - metadata.index(m)])
                         ax_legend.legend(title=m, handles=handles)
-                        ax_legend.axis("off")
+                        ax_legend.axis('off')
                         fig.add_subplot(ax_legend)
                     else:
-                        axs[0, 0].scatter(
-                            x,
-                            y,
-                            c=color,
-                            cmap=self.metadataColors[m].get_cmap(),
-                            s=1600,
-                            marker="s",
-                        )
+                        axs[0, 0].scatter(x, y, c=color, cmap=self.metadataColors[m].get_cmap(),
+                                          s=1600, marker='s')
 
-                        ax_legend = plt.Subplot(
-                            fig, axs_legend[len(metadata) - 1 - metadata.index(m)]
-                        )
-                        clb = fig.colorbar(
-                            mappable=self.metadataColors[m],
-                            ax=ax_legend,
-                            orientation="horizontal",
-                            fraction=0.9,
-                        )
+                        ax_legend = plt.Subplot(fig, axs_legend[len(metadata) - 1 - metadata.index(m)])
+                        clb = fig.colorbar(mappable=self.metadataColors[m],
+                                           ax=ax_legend,
+                                           orientation='horizontal',
+                                           fraction=0.9)
                         clb.ax.set_title(m.capitalize())
-                        ax_legend.axis("off")
+                        ax_legend.axis('off')
                         fig.add_subplot(ax_legend)
 
-                axs[0, 0].set_title(
-                    f"Module Eigengene for {moduleName}", size=28, fontweight="bold"
-                )
+                axs[0, 0].set_title(f"Module Eigengene for {moduleName}", size=28, fontweight="bold")
                 axs[0, 0].set_ylim(-2000, np.max(y) + 2000)
                 axs[0, 0].grid(False)
-                axs[0, 0].axis("off")
+                axs[0, 0].axis('off')
 
-                axs[1, 0].bar(ind, ME.eigengeneExp, align="center", color="black")
-                axs[1, 0].set_ylabel("eigengeneExp")
-                axs[1, 0].set_facecolor("white")
+                axs[1, 0].bar(ind, ME.eigengeneExp, align='center', color='black')
+                axs[1, 0].set_ylabel('eigengeneExp')
+                axs[1, 0].set_facecolor('white')
 
                 cmap = sns.color_palette("dark:red", as_cmap=True)
-                sns.heatmap(
-                    heatmap,
-                    cmap=cmap,
-                    cbar=False,  # cbar_ax=axs[2,1],
-                    yticklabels=False,
-                    xticklabels=False,
-                    ax=axs[2, 0],
-                )
+                sns.heatmap(heatmap, cmap=cmap,
+                            cbar=False,  # cbar_ax=axs[2,1],
+                            yticklabels=False, xticklabels=False,
+                            ax=axs[2, 0])
             else:
-                fig, axs = plt.subplots(
-                    nrows=2,
-                    ncols=1,
-                    figsize=(ME.shape[0], 20),
-                    sharex="col",
-                    gridspec_kw={"height_ratios": [1, 1.5]},
-                    facecolor="white",
-                )
+                fig, axs = plt.subplots(nrows=2, ncols=1, figsize=(ME.shape[0], 20),
+                                        sharex='col', gridspec_kw={
+                        'height_ratios': [1, 1.5]}, facecolor='white')
 
-                axs[0].set_title(
-                    f"Module Eigengene for {moduleName}", size=28, fontweight="bold"
-                )
-                axs[0].bar(ind, ME.eigengeneExp, align="center", color="black")
-                axs[0].set_ylabel("eigengeneExp")
+                axs[0].set_title(f"Module Eigengene for {moduleName}", size=28, fontweight="bold")
+                axs[0].bar(ind, ME.eigengeneExp, align='center', color='black')
+                axs[0].set_ylabel('eigengeneExp')
 
                 cmap = sns.color_palette("dark:red", as_cmap=True)
-                sns.heatmap(
-                    heatmap,
-                    cmap=cmap,
-                    cbar=False,  # cbar_ax=axs[2,1],
-                    yticklabels=False,
-                    xticklabels=False,
-                    ax=axs[1],
-                )
+                sns.heatmap(heatmap, cmap=cmap,
+                            cbar=False,  # cbar_ax=axs[2,1],
+                            yticklabels=False, xticklabels=False,
+                            ax=axs[1])
 
             if self.save:
-                fig.savefig(
-                    f"{self.outputPath}figures/"
-                    f"{self.name}_module_heatmap_eigengene_{moduleName}.{self.figureType}",
-                    bbox_inches="tight",
-                )
+                fig.savefig(f"{self.outputPath}figures/"\
+                            f"{self.name}_module_heatmap_eigengene_{moduleName}.{self.figureType}", \
+                            bbox_inches='tight')
             if not show:
                 plt.close(fig)
             else:
@@ -3918,9 +3059,7 @@ class WGCNA(GeneExp):
 
         return None
 
-    def barplotModuleEigenGene(
-        self, moduleName, metadata, combine=True, colorBar=None, show=True
-    ):
+    def barplotModuleEigenGene(self, moduleName, metadata, combine=True, colorBar=None, show=True):
         """
         bar plot of module eigen gene figure in given module
 
@@ -3938,8 +3077,7 @@ class WGCNA(GeneExp):
         sampleInfo = self.datExpr.obs
         if sampleInfo.shape[1] == 0:
             print(
-                f"{WARNING}There is not any sample information in given object! Skip running barplotModuleEigenGene() function.{ENDC}"
-            )
+                f"{WARNING}There is not any sample information in given object! Skip running barplotModuleEigenGene() function.{ENDC}")
             return None
 
         height_ratios = []
@@ -3950,51 +3088,39 @@ class WGCNA(GeneExp):
                 height_ratios.append(1)
         height_ratios.reverse()
 
-        modules = np.unique(self.datExpr.var["moduleColors"]).tolist()
+        modules = np.unique(self.datExpr.var['moduleColors']).tolist()
         if np.all(moduleName not in modules):
             print(f"{WARNING}Module name does not exist in {ENDC}")
             return None
         else:
-            ME = pd.DataFrame(
-                self.datME["ME" + moduleName].values, columns=["eigengeneExp"]
-            )
+            ME = pd.DataFrame(self.datME["ME" + moduleName].values, columns=['eigengeneExp'])
 
             if combine:
                 df = ME.copy(deep=True)
-                df["all"] = ""
+                df['all'] = ''
                 for m in metadata:
                     df[m] = sampleInfo[m].values
                     df.sort_values(by=m, inplace=True)
-                    df[m] = (
-                        df[m].astype(str).str.replace("_", "-")
-                    )  # Replace underscores with dashes
-                    df["all"] = df["all"] + "_" + df[m].astype(str)
-                df["all"] = df["all"].apply(lambda x: x[1:])
-                cat = pd.DataFrame(pd.unique(df["all"]), columns=["all"])
-                cat[metadata] = cat["all"].str.split("_", expand=True)
-                for col in cat.columns:  # switch back dashes to underscores
-                    cat[col] = cat[col].str.replace(
-                        "-", "_"
-                    )  # switch back dashes to underscores
-                df["all"] = (
-                    df["all"].astype(str).str.replace("-", "_")
-                )  # switch back dashes to underscores
-                ybar = (
-                    df[["all", "eigengeneExp"]].groupby(["all"]).mean()["eigengeneExp"]
-                )
-                ebar = (
-                    df[["all", "eigengeneExp"]].groupby(["all"]).std()["eigengeneExp"]
-                )
-                ybar = ybar.loc[cat["all"]]
-                ebar = ebar.loc[cat["all"]]
+                    df[m] = df[m].astype(str).str.replace('_', '-') # Replace underscores with dashes
+                    df['all'] = df['all'] + '_' + df[m].astype(str)
+                df['all'] = df['all'].apply(lambda x: x[1:])
+                cat = pd.DataFrame(pd.unique(df['all']), columns=['all'])
+                cat[metadata] = cat['all'].str.split('_', expand=True)
+                for col in cat.columns: # switch back dashes to underscores
+                    cat[col] = cat[col].str.replace('-', '_') # switch back dashes to underscores
+                df['all'] = df['all'].astype(str).str.replace('-', '_') # switch back dashes to underscores
+                ybar = df[['all', 'eigengeneExp']].groupby(['all']).mean()['eigengeneExp']
+                ebar = df[['all', 'eigengeneExp']].groupby(['all']).std()['eigengeneExp']
+                ybar = ybar.loc[cat['all']]
+                ebar = ebar.loc[cat['all']]
                 label = list(ybar.index)
-                dot = df[["all", "eigengeneExp"]].copy()
+                dot = df[['all', 'eigengeneExp']].copy()
                 ind = {}
                 for i in range(cat.shape[0]):
-                    ind[cat.loc[i, "all"]] = cat.index[i]
+                    ind[cat.loc[i, 'all']] = cat.index[i]
                 dot.replace(ind, inplace=True)
-                xdot = dot["all"]
-                ydot = dot["eigengeneExp"]
+                xdot = dot['all']
+                ydot = dot['eigengeneExp']
 
                 if colorBar is None:
                     palette = "lightblue"
@@ -4004,87 +3130,56 @@ class WGCNA(GeneExp):
                     palette = palette[colorBar].values
                 else:
                     palette = cat[[colorBar]].copy()
-                    palette[[colorBar]] = palette[[colorBar]].astype("int")
-                    palette[colorBar] = palette[colorBar].apply(
-                        lambda x: mcolors.to_hex(
-                            self.metadataColors[colorBar].to_rgba(float(x))
-                        )
-                        if pd.notna(x)
-                        else "#FFFFFF"
-                    )
+                    palette[[colorBar]] = palette[[colorBar]].astype('int')
+                    palette[colorBar] = palette[colorBar].apply(lambda x: mcolors.to_hex(self.metadataColors[colorBar].to_rgba(float(x))) if pd.notna(x) else "#FFFFFF")
                     palette = palette[colorBar].values
 
-                fig, axs = plt.subplots(
-                    nrows=2,
-                    ncols=2,
-                    figsize=(cat.shape[0] + 2, len(metadata) * 4),
-                    sharex="col",
-                    gridspec_kw={
-                        "height_ratios": [len(metadata) * 0.4, len(metadata) * 0.6],
-                        "width_ratios": [cat.shape[0], 3],
-                    },
-                )
+                fig, axs = plt.subplots(nrows=2, ncols=2, figsize=(cat.shape[0] + 2, len(metadata) * 4),
+                                        sharex='col', gridspec_kw={
+                        'height_ratios': [len(metadata) * 0.4, len(metadata) * 0.6],
+                        'width_ratios': [cat.shape[0], 3]})
 
                 gs = axs[0, 1].get_gridspec()
                 # remove the underlying axes
                 for ax in axs[:, 1]:
                     ax.remove()
                 ax_legend = fig.add_subplot(gs[:, 1])
-                ax_legend.axis("off")
-                axs_legend = gridspec.GridSpecFromSubplotSpec(
-                    len(metadata),
-                    1,
-                    subplot_spec=ax_legend.get_subplotspec(),
-                    height_ratios=height_ratios,
-                )
+                ax_legend.axis('off')
+                axs_legend = gridspec.GridSpecFromSubplotSpec(len(metadata), 1,
+                                                              subplot_spec=ax_legend.get_subplotspec(),
+                                                              height_ratios=height_ratios)
 
                 ind = [i for i in range(cat.shape[0])]
                 for m in metadata:
                     handles = []
                     x = ind
                     y = np.repeat(3000 * metadata.index(m), len(ind))
-                    color = list(cat[m].values)
+                    color = cat[m].values
                     if type(self.metadataColors[m]) == dict:
                         for n in list(self.metadataColors[m].keys()):
-                            color = [
-                                self.metadataColors[m][n] if c == n else c
-                                for c in color
-                            ]
-                            patch = mpatches.Patch(
-                                color=self.metadataColors[m][n], label=n
-                            )
+                            color = np.where(color == n, self.metadataColors[m][n], color)
+                            patch = mpatches.Patch(color=self.metadataColors[m][n], label=n)
                             handles.append(patch)
                         if m != colorBar:
-                            axs[0, 0].scatter(x, y, c=color, s=1600, marker="s")
-                        ax_legend = plt.Subplot(
-                            fig, axs_legend[len(metadata) - 1 - metadata.index(m)]
-                        )
+                            axs[0, 0].scatter(x, y, c=color, s=1600, marker='s')
+                        ax_legend = plt.Subplot(fig, axs_legend[len(metadata) - 1 - metadata.index(m)])
                         ax_legend.legend(title=m, handles=handles)
-                        ax_legend.axis("off")
+                        ax_legend.axis('off')
                         fig.add_subplot(ax_legend)
                     else:
-                        cat[m] = cat[m].astype("float")
+                        cat[m] = cat[m].astype('float')
                         color = cat[m].values
-                        axs[0, 0].scatter(
-                            x,
-                            y,
-                            c=color,
-                            cmap=self.metadataColors[m].get_cmap(),
-                            s=1600,
-                            marker="s",
-                        )
+                        axs[0, 0].scatter(x, y, c=color,
+                                          cmap=self.metadataColors[m].get_cmap(),
+                                          s=1600, marker='s')
 
-                        ax_legend = plt.Subplot(
-                            fig, axs_legend[len(metadata) - 1 - metadata.index(m)]
-                        )
-                        clb = fig.colorbar(
-                            mappable=self.metadataColors[m],
-                            ax=ax_legend,
-                            orientation="horizontal",
-                            fraction=0.9,
-                        )
+                        ax_legend = plt.Subplot(fig, axs_legend[len(metadata) - 1 - metadata.index(m)])
+                        clb = fig.colorbar(mappable=self.metadataColors[m],
+                                           ax=ax_legend,
+                                           orientation='horizontal',
+                                           fraction=0.9)
                         clb.ax.set_title(m.capitalize())
-                        ax_legend.axis("off")
+                        ax_legend.axis('off')
                         fig.add_subplot(ax_legend)
                     # if m != colorBar:
                     #     axs[0, 0].scatter(x, y, c=color, s=1600, marker='s')
@@ -4093,66 +3188,49 @@ class WGCNA(GeneExp):
                     # ax_legend.axis('off')
                     # fig.add_subplot(ax_legend)
 
-                axs[0, 0].set_title(
-                    f"Module Eigengene for {moduleName}", size=28, fontweight="bold"
-                )
+                axs[0, 0].set_title(f"Module Eigengene for {moduleName}", size=28, fontweight="bold")
                 axs[0, 0].set_ylim(-2000, np.max(y) + 2000)
                 axs[0, 0].grid(False)
-                axs[0, 0].axis("off")
+                axs[0, 0].axis('off')
 
                 ind = [i for i in range(cat.shape[0])]
-                axs[1, 0].bar(ind, ybar, align="center", color=palette)
+                axs[1, 0].bar(ind, ybar, align='center', color=palette)
                 axs[1, 0].errorbar(ind, ybar, yerr=ebar, fmt="o", color="r")
-                axs[1, 0].scatter(xdot, ydot, c="black", alpha=0.5)
+                axs[1, 0].scatter(xdot, ydot, c='black', alpha=0.5)
                 axs[1, 0].set_xticks(np.arange(len(ind)))
                 axs[1, 0].set_xticklabels(label, rotation=90)
-                axs[1, 0].set_ylabel("eigengeneExp")
-                axs[1, 0].set_facecolor("white")
+                axs[1, 0].set_ylabel('eigengeneExp')
+                axs[1, 0].set_facecolor('white')
                 fig.subplots_adjust(bottom=0.3)
-                fig.savefig(
-                    f"{self.outputPath}figures/"
-                    f"{self.name}_module_barplot_eigengene_{moduleName}.{self.figureType}",
-                    bbox_inches="tight",
-                )
+                fig.savefig(f"{self.outputPath}figures/"\
+                            f"{self.name}_module_barplot_eigengene_{moduleName}.{self.figureType}", \
+                            bbox_inches='tight')
                 if not show:
                     plt.close(fig)
 
             else:
-                fig, axs = plt.subplots(
-                    nrows=1, ncols=len(metadata), figsize=(5 * len(metadata), 5)
-                )
+                fig, axs = plt.subplots(nrows=1, ncols=len(metadata), figsize=(5 * len(metadata), 5))
 
                 for i in range(len(metadata)):
                     df = ME.copy(deep=True)
                     df[metadata[i]] = sampleInfo[metadata[i]].values
                     df.sort_values(by=metadata[i], inplace=True)
                     palette = self.metadataColors[metadata[i]]
-                    bar = sns.barplot(
-                        x=metadata[i],
-                        y="eigengeneExp",
-                        data=df,
-                        palette=palette,
-                        ci="sd",
-                        capsize=0.1,
-                        ax=axs[i],
-                    )
+                    bar = sns.barplot(x=metadata[i], y="eigengeneExp", data=df, palette=palette, ci='sd', capsize=0.1,
+                                      ax=axs[i])
                     if i != 0:
                         bar.set(ylabel=None)
 
                 if self.save:
-                    fig.savefig(
-                        f"{self.outputPath}figures/"
-                        f"{self.name}_module_barplot_eigengene_{moduleName}.{self.figureType}",
-                        bbox_inches="tight",
-                    )
+                    fig.savefig(f"{self.outputPath}figures/"\
+                                f"{self.name}_module_barplot_eigengene_{moduleName}.{self.figureType}", \
+                                bbox_inches='tight')
                 if not show:
                     plt.close(fig)
                 else:
                     return axs
 
-    def functional_enrichment_analysis(
-        self, type, moduleName, sets=None, p_value=1, file_name=None, **kwargs
-    ):
+    def functional_enrichment_analysis(self, type, moduleName, sets=None, p_value=1, file_name=None, **kwargs):
         """
         Doing functional enrichment analysis including GO, KEGG and REACTOME
 
@@ -4175,15 +3253,13 @@ class WGCNA(GeneExp):
         if file_name is None:
             file_name = moduleName
 
-        modules = np.unique(self.datExpr.var["moduleColors"]).tolist()
+        modules = np.unique(self.datExpr.var['moduleColors']).tolist()
         if np.all(moduleName not in modules):
             print(f"{WARNING}Module name does not exist in {ENDC}")
             return
 
         if not os.path.exists(f"{self.outputPath}figures/{self.name}_{type}"):
-            print(
-                f"{WARNING}{type} directory does not exist!\nCreating {self.name}_{type} directory!{ENDC}"
-            )
+            print(f"{WARNING}{type} directory does not exist!\nCreating {self.name}_{type} directory!{ENDC}")
             os.makedirs(f"{self.outputPath}figures/{self.name}_{type}")
 
         if type == "GO" and sets is None:
@@ -4191,62 +3267,48 @@ class WGCNA(GeneExp):
         elif type == "KEGG" and sets is None:
             sets = ["KEGG_2016"]
 
-        geneModule = self.datExpr.var.gene_name[
-            self.datExpr.var.moduleColors == moduleName
-        ].astype(str)
+        geneModule = self.datExpr.var.gene_name[self.datExpr.var.moduleColors == moduleName].astype(str)
         geneModule = geneModule.fillna("").values.tolist()
 
         if type in ["GO", "KEGG"]:
             try:
-                enr = gp.enrichr(
-                    gene_list=geneModule,
-                    gene_sets=sets,
-                    organism=self.species,
-                    outdir=f"{self.outputPath}figures/{self.name}_{type}/{file_name}",
-                    cutoff=p_value,
-                    **kwargs,
-                )
-                dotplot(
-                    enr.res2d,
-                    title=f"Gene ontology in {moduleName} module",
-                    cmap="viridis_r",
-                    cutoff=p_value,
-                    ofname=f"{self.outputPath}figures/{self.name}_{type}/{file_name}.{self.figureType}",
-                )
+                enr = gp.enrichr(gene_list=geneModule,
+                                 gene_sets=sets,
+                                 organism=self.species,
+                                 outdir=f"{self.outputPath}figures/{self.name}_{type}/{file_name}",
+                                 cutoff=p_value,
+                                 **kwargs)
+                dotplot(enr.res2d,
+                        title=f"Gene ontology in {moduleName} module",
+                        cmap='viridis_r',
+                        cutoff=p_value,
+                        ofname=f"{self.outputPath}figures/{self.name}_{type}/{file_name}.{self.figureType}")
             except:
                 print(f"No enrich terms when cutoff = {p_value} in module {moduleName}")
         else:
             numGeneModule = len(geneModule)
             geneModule = ",".join(geneModule)
-            result = analysis.identifiers(
-                ids=geneModule, species=self.species, p_value=str(p_value)
-            )
-            token = result["summary"]["token"]
-            analysis.report(
-                token,
-                path=f"{self.outputPath}figures/{self.name}_{type}/",
-                file=f"{file_name}.{self.figureType}",
-                number="50",
-                species=self.species,
-            )
-            token_result = analysis.token(
-                token, species=self.species, p_value=str(p_value)
-            )
+            result = analysis.identifiers(ids=geneModule,
+                                          species=self.species,
+                                          p_value=str(p_value))
+            token = result['summary']['token']
+            analysis.report(token,
+                            path=f"{self.outputPath}figures/{self.name}_{type}/",
+                            file=f"{file_name}.{self.figureType}",
+                            number='50',
+                            species=self.species)
+            token_result = analysis.token(token,
+                                          species=self.species,
+                                          p_value=str(p_value))
 
             print(
-                f"{numGeneModule - token_result['identifiersNotFound']} out of {numGeneModule} genes (identifiers) in the sample were found in Reactome."
-            )
+                f"{numGeneModule - token_result['identifiersNotFound']} out of {numGeneModule} genes (identifiers) in the sample were found in Reactome.")
             print(
-                f"{token_result['resourceSummary'][0]['pathways']} pathways were hit by at least one of them, which {len(token_result['pathways'])} of them have p-value less than {p_value}."
-            )
-            print(
-                f"Report was saved {self.outputPath}figures/{self.name}_{type}/{file_name}.{self.figureType}!"
-            )
-            print(
-                f"For more information please visit https://reactome.org/PathwayBrowser/#/DTAB=AN&ANALYSIS={token}"
-            )
+                f"{token_result['resourceSummary'][0]['pathways']} pathways were hit by at least one of them, which {len(token_result['pathways'])} of them have p-value less than {p_value}.")
+            print(f"Report was saved {self.outputPath}figures/{self.name}_{type}/{file_name}.{self.figureType}!")
+            print(f"For more information please visit https://reactome.org/PathwayBrowser/#/DTAB=AN&ANALYSIS={token}")
 
-    def updateGeneInfo(self, geneInfo=None, path=None, sep=","):
+    def updateGeneInfo(self, geneInfo=None, path=None, sep=','):
         """
         add/update genes info in datExpr and geneExpr anndata
 
@@ -4261,7 +3323,7 @@ class WGCNA(GeneExp):
         self.geneExpr = GeneExp.updateGeneInfo(self.geneExpr, geneInfo, path, sep)
         self.datExpr = GeneExp.updateGeneInfo(self.datExpr, geneInfo, path, sep)
 
-    def updateSampleInfo(self, sampleInfo=None, path=None, sep=","):
+    def updateSampleInfo(self, sampleInfo=None, path=None, sep=','):
         """
         add/update metadata in datExpr and geneExpr anndata
 
@@ -4277,15 +3339,8 @@ class WGCNA(GeneExp):
         self.datExpr = GeneExp.updateSampleInfo(self.datExpr, sampleInfo, path, sep)
 
     @staticmethod
-    def softConnectivity(
-        datExpr,
-        corOptions=pd.DataFrame(),
-        weights=None,
-        type="unsigned",
-        power=6,
-        blockSize=1500,
-        minNSamples=None,
-    ):
+    def softConnectivity(datExpr, corOptions=pd.DataFrame(), weights=None, type="unsigned", power=6, blockSize=1500,
+                         minNSamples=None):
         """
         Given expression data or a similarity, the function constructs the adjacency matrix and for each node calculates its connectivity, that is the sum of the adjacency to the other nodes.
 
@@ -4323,27 +3378,19 @@ class WGCNA(GeneExp):
             sys.exit(
                 f"Error: Something seems to be wrong. \n Make sure that the input data frame has genes as rows and "
                 f"array samples as columns.\n Alternatively, there seem to be fewer than 10 genes or fewer than "
-                f"{minNSamples} samples."
-            )
+                f"{minNSamples} samples.")
         if nGenes < nSamples:
             print(
                 f"{WARNING}Warning: There are fewer genes than samples in the function softConnectivity. Maybe you "
-                f"should transpose the data?{ENDC}"
-            )
+                f"should transpose the data?{ENDC}")
 
         k = np.zeros((nGenes,))
         start = 1
         while start < nGenes:
             end = min(start + blockSize - 1, nGenes)
             index1 = range(start, end)
-            ad1 = WGCNA.adjacency(
-                datExpr,
-                weights=weights,
-                selectCols=index1,
-                power=power,
-                adjacencyType=type,
-                corOptions=corOptions,
-            )
+            ad1 = WGCNA.adjacency(datExpr, weights=weights, selectCols=index1, power=power, adjacencyType=type,
+                                  corOptions=corOptions)
             k[index1] = ad1.sum(axis=1) - 1
             # If fewer than minNSamples contain gene expression information for a given
             # gene, then we set its connectivity to 0.
@@ -4374,9 +3421,7 @@ class WGCNA(GeneExp):
             sys.exit("input matrix is not a square matrix.")
 
         if mat.shape[0] != len(colors):
-            sys.exit(
-                "Dimensions of matrix (number of genes) and length of 'colors' differ."
-            )
+            sys.exit("Dimensions of matrix (number of genes) and length of 'colors' differ.")
 
         nNodes = len(colors)
         colorLevels = pd.Categorical(colors).categories
@@ -4399,9 +3444,7 @@ class WGCNA(GeneExp):
         if scaleByMax:
             kOut = np.zeros((nNodes,))
         kDiff = np.subtract(kWithin, kOut)
-        res = pd.DataFrame(
-            {"kTotal": kTotal, "kWithin": kWithin, "kOut": kOut, "kDiff": kDiff}
-        )
+        res = pd.DataFrame({'kTotal': kTotal, 'kWithin': kWithin, 'kOut': kOut, 'kDiff': kDiff})
         if index is not None:
             res.index = index
         return res
@@ -4420,29 +3463,21 @@ class WGCNA(GeneExp):
         """
         corOptions = []
         if self.datME.shape[0] != self.datExpr.to_df().shape[0]:
-            sys.exit(
-                "Number of samples (rows) in 'datExpr' and 'datME' must be the same."
-            )
+            sys.exit("Number of samples (rows) in 'datExpr' and 'datME' must be the same.")
         datExpr = self.datExpr.to_df()
         datME = self.datME
         if exprWeights is not None:
-            exprWeights = WGCNA.checkAndScaleWeights(
-                exprWeights, datExpr, scaleByMax=False
-            )
+            exprWeights = WGCNA.checkAndScaleWeights(exprWeights, datExpr, scaleByMax=False)
         if MEWeights is not None:
             MEWeights = WGCNA.checkAndScaleWeights(exprWeights, datME, scaleByMax=False)
 
         varianceZeroIndicatordatExpr = sum(datExpr.var(axis=0) == 0)
         varianceZeroIndicatordatME = sum(datME.var(axis=0) == 0)
         if varianceZeroIndicatordatExpr > 0:
-            print(
-                f"{WARNING}Some genes are constant. Hint: consider removing constant columns from datExpr.{ENDC}"
-            )
+            print(f"{WARNING}Some genes are constant. Hint: consider removing constant columns from datExpr.{ENDC}")
         if varianceZeroIndicatordatME > 0:
-            print(
-                f"{WARNING}Some module eigengenes are constant, which is suspicious. Hint: consider removing "
-                f"constant columns from datME.{ENDC}"
-            )
+            print(f"{WARNING}Some module eigengenes are constant, which is suspicious. Hint: consider removing "
+                  f"constant columns from datME.{ENDC}")
         if MEWeights is not None:
             corOptions.append("weights.y = MEWeights, ")
         if exprWeights is not None:
@@ -4451,21 +3486,10 @@ class WGCNA(GeneExp):
         output = np.corrcoef(datExpr.T, datME.T)
         tmp = len(datME.columns)
         col = ["k" + datME.columns[i] for i in range(tmp)]
-        self.signedKME = pd.DataFrame(
-            output[0 : datExpr.shape[1], datExpr.shape[1] :],
-            index=datExpr.columns,
-            columns=col,
-        )
+        self.signedKME = pd.DataFrame(output[0:datExpr.shape[1], datExpr.shape[1]:],
+                                      index=datExpr.columns, columns=col)
 
-    def CoexpressionModulePlot(
-        self,
-        modules,
-        numGenes=10,
-        numConnections=100,
-        minTOM=0,
-        filters=None,
-        file_name=None,
-    ):
+    def CoexpressionModulePlot(self, modules, numGenes=10, numConnections=100, minTOM=0, filters=None, file_name=None):
         """
         plot Coexpression for given module
 
@@ -4488,9 +3512,7 @@ class WGCNA(GeneExp):
             print("signedKME is empty! call signedKME() to calculate it")
 
         if not os.path.exists(f"{self.outputPath}figures/network/"):
-            print(
-                f"{WARNING}Network directory does not exist!\nCreating network directory!{ENDC}"
-            )
+            print(f"{WARNING}Network directory does not exist!\nCreating network directory!{ENDC}")
             os.makedirs(f"{self.outputPath}figures/network/")
 
         gene_id = self.datExpr.var.loc[self.datExpr.var.moduleColors.isin(modules), :]
@@ -4504,9 +3526,7 @@ class WGCNA(GeneExp):
             numConnections = numGenes * (numGenes - 1)
         genes = []
         for module in modules:
-            mat = self.signedKME.loc[gene_id.index].sort_values(
-                ["kME" + module], ascending=False
-            )
+            mat = self.signedKME.loc[gene_id.index].sort_values(["kME" + module], ascending=False)
             mat = mat.iloc[:numGenes, :]
             genes = genes + mat.index.tolist()
 
@@ -4518,53 +3538,37 @@ class WGCNA(GeneExp):
         adj = adj.stack().nlargest(numConnections)
 
         net = Network()
-        gene_id = list(adj.index.get_level_values(0)) + list(
-            adj.index.get_level_values(1)
-        )
+        gene_id = list(adj.index.get_level_values(0)) + list(adj.index.get_level_values(1))
         gene_id = np.unique(gene_id)
         nodes = self.datExpr.var.loc[gene_id, :]
         node_color = nodes["moduleColors"].tolist()
-        nodes.drop(
-            ["dynamicColors", "moduleColors", "moduleLabels"], axis=1, inplace=True
-        )
+        nodes.drop(["dynamicColors", "moduleColors", "moduleLabels"], axis=1, inplace=True)
         title = nodes.index.tolist()
         for i in range(nodes.shape[0]):
             for j in range(nodes.shape[1]):
                 if not pd.isna(nodes.iloc[i, j]):
-                    title[i] = (
-                        title[i]
-                        + "\n"
-                        + str(nodes.columns[j])
-                        + ": "
-                        + str(nodes.iloc[i, j])
-                    )
+                    title[i] = title[i] + "\n" + str(nodes.columns[j]) + ": " + str(nodes.iloc[i, j])
 
-        net.add_nodes(
-            nodes.index.tolist(),
-            title=title,
-            label=nodes.index.tolist(),
-            color=node_color,
-        )
+        net.add_nodes(nodes.index.tolist(),
+                      title=title,
+                      label=nodes.index.tolist(),
+                      color=node_color)
 
         for i in range(len(adj)):
             if adj[i] != 0:
-                net.add_edge(
-                    adj.index.get_level_values(0)[i],
-                    adj.index.get_level_values(1)[i],
-                    weight=adj[i],
-                )
+                net.add_edge(adj.index.get_level_values(0)[i],
+                             adj.index.get_level_values(1)[i],
+                             weight=adj[i])
 
         if file_name is None:
             if len(modules) <= 3:
-                file_name = "_".join(modules)
+                file_name = '_'.join(modules)
             else:
                 file_name = "network"
 
         net.show(f"{self.outputPath}figures/network/{file_name}.html")
 
-    def PPI_network(
-        self, species, moduleName=None, geneList=None, output_format="image"
-    ):
+    def PPI_network(self, species, moduleName=None, geneList=None, output_format="image"):
         """
         retrieve an image of a STRING network of a neighborhood surrounding one or more proteins or ask STRING to show only the network of interactions between your input proteins.
 
@@ -4588,9 +3592,7 @@ class WGCNA(GeneExp):
             sys.exit("geneList or moduleName should be empty at the same time!")
 
         if not os.path.exists(f"{self.outputPath}figures/PPI/"):
-            print(
-                f"{WARNING}PPI directory does not exist!\nCreating PPI directory!{ENDC}"
-            )
+            print(f"{WARNING}PPI directory does not exist!\nCreating PPI directory!{ENDC}")
             os.makedirs(f"{self.outputPath}figures/PPI/")
 
         res = WGCNA.request_PPI(genes=geneList, species=species)
@@ -4610,21 +3612,18 @@ class WGCNA(GeneExp):
                 "species": species,  # species NCBI identifier
                 "add_white_nodes": 15,  # add 15 white nodes to my protein
                 "network_flavor": "confidence",  # show confidence links
-                "caller_identity": "www.awesome_app.org",  # your app name
+                "caller_identity": "www.awesome_app.org"  # your app name
+
             }
-            WGCNA.request_PPI_image(
-                params=params,
-                genes=genes,
-                file_name=f"{self.outputPath}figures/PPI/{tmp.gene1.tolist()[0]}_PPI.png",
-                request_url=request_url,
-            )
+            WGCNA.request_PPI_image(params=params,
+                                    genes=genes,
+                                    file_name=f"{self.outputPath}figures/PPI/{tmp.gene1.tolist()[0]}_PPI.png",
+                                    request_url=request_url)
         return res
 
     @staticmethod
-    def request_PPI_subset(
-        params,
-        request_url="https://version-11-5.string-db.org/api/tsv-no-header/interaction_partners",
-    ):
+    def request_PPI_subset(params,
+                           request_url='https://version-11-5.string-db.org/api/tsv-no-header/interaction_partners'):
         """
         request STRING to find genes interact with our gene list base
 
@@ -4643,9 +3642,7 @@ class WGCNA(GeneExp):
             for line in response.text.strip().split("\n"):
                 l = line.strip().split("\t")
 
-                tmp = pd.DataFrame(
-                    {"gene1": l[2], "gene2": l[3], "score": l[5]}, index=[0]
-                )
+                tmp = pd.DataFrame({'gene1': l[2], 'gene2': l[3], 'score': l[5]}, index=[0])
                 res = pd.concat([res, tmp], ignore_index=True)
 
         sleep(1)
@@ -4653,7 +3650,8 @@ class WGCNA(GeneExp):
         return res
 
     @staticmethod
-    def request_PPI(genes, species):
+    def request_PPI(genes,
+                    species):
         """
         Getting all the STRING interaction partners of the protein set
 
@@ -4675,34 +3673,31 @@ class WGCNA(GeneExp):
         count = 0
         res = pd.DataFrame(columns=["gene1", "gene2", "score"])
         while count < len(genes):
+
             if count + 2000 > len(genes):
                 my_genes = genes[count:]
             else:
-                my_genes = genes[count : count + 2000]
+                my_genes = genes[count:count + 2000]
 
             params = {
                 "identifiers": "%0d".join(my_genes),  # your protein
                 "species": species,  # species NCBI identifier
                 "limit": 5,
-                "caller_identity": "www.awesome_app.org",  # your app name
+                "caller_identity": "www.awesome_app.org"  # your app name
             }
 
             tmp = WGCNA.request_PPI_subset(params, request_url)
             count = count + 2000
             res = pd.concat([res, tmp], ignore_index=True)
 
-        print(
-            f"{len(res.gene1.unique().tolist())} genes out of {len(genes)} genes have PPI."
-        )
+        print(f"{len(res.gene1.unique().tolist())} genes out of {len(genes)} genes have PPI.")
         return res
 
     @staticmethod
-    def request_PPI_image(
-        params,
-        genes,
-        file_name,
-        request_url="https://version-11-5.string-db.org/api/image/network",
-    ):
+    def request_PPI_image(params,
+                          genes,
+                          file_name,
+                          request_url='https://version-11-5.string-db.org/api/image/network'):
         """
         plot PPI interaction along with link that direct you to the STRING webpage
 
@@ -4721,14 +3716,12 @@ class WGCNA(GeneExp):
         if response.status_code == 200:
             print("Saving interaction network to %s" % file_name)
 
-            with open(file_name, "wb") as fh:
+            with open(file_name, 'wb') as fh:
                 fh.write(response.content)
 
             print("For having interactive network, click line below:")
             tmp = "%0d".join(genes)
-            print(
-                f"https://string-db.org/api/tsv/get_link?identifiers={tmp}&species={params['species']}"
-            )
+            print(f"https://string-db.org/api/tsv/get_link?identifiers={tmp}&species={params['species']}")
 
         sleep(1)
 
@@ -4745,21 +3738,20 @@ class WGCNA(GeneExp):
         :rtype: pandas dataframe
         """
 
-        modules = np.unique(self.datExpr.var["moduleColors"]).tolist()
+        modules = np.unique(self.datExpr.var['moduleColors']).tolist()
         if np.all(moduleName not in modules):
             print(f"{WARNING}Module name does not exist in {ENDC}")
             return
 
         datExpr = self.datExpr.copy()
-        datExpr = datExpr[:, datExpr.var["moduleColors"] == moduleName]
-        adj = WGCNA.adjacency(
-            datExpr.to_df(), power=self.power, adjacencyType=self.networkType
-        )
-        adj = pd.DataFrame(
-            adj, columns=datExpr.to_df().columns, index=datExpr.to_df().columns
-        )
+        datExpr = datExpr[:, datExpr.var['moduleColors'] == moduleName]
+        adj = WGCNA.adjacency(datExpr.to_df(), power=self.power, adjacencyType=self.networkType)
+        adj = pd.DataFrame(adj,
+                           columns=datExpr.to_df().columns,
+                           index=datExpr.to_df().columns)
         hub_genes = adj.sum().sort_values(ascending=False)
-        hub_genes = pd.DataFrame(hub_genes, columns=["connectivity"])
+        hub_genes = pd.DataFrame(hub_genes,
+                                 columns=["connectivity"])
 
         hub_genes = pd.concat([hub_genes, datExpr.var], axis=1)
         hub_genes = hub_genes.iloc[:n, :]


### PR DESCRIPTION
Hello,

Thank you for all the effort in making the PyWGCNA package, I frequently find it useful. That said, I encountered an error when including a column of integer values (timepoint) in the anndata.obs that I used to initialize the WGCNA object. When `WGCNA.analyzeWGCNA()` is called I get an error: 
```
ValueError: 'c' argument must be a color, a sequence of colors, or a sequence of numbers, not array(['#D62628', '#D62628', '#D62628', '#D62628', '2', '4', '4', '4',
       '4', '0', '0', '0', '0', '#D62628', '3', '3', '3', '3'],
      dtype='<U11')
```

I found that this occurs because the use of `color = np.where(color == n, self.metadataColors[m][n], color)`. `color` starts as a numpy array of int, but when some of the values are replaced with the string values of the colors from `metadataColors`, the entire array is coerced to str type, which causes subsequent comparisons to `n` (an integer) to all be false.

I also hit a snag with `elif type(colorBar) == dict:` which causes all `metadataColors` to be treated as a `ScalarMappable`, but once I fixed that and cleaned up a few other things, I believe I was able to get everything working the way I expect, so I made this pull request. I don't have much experience with public pull requests, so if I'm missing anything please let me know.

Best regards,
John Sherman