### PR TITLE
Patch for singleton module error

### DIFF
--- a/PyWGCNA/wgcna.py
+++ b/PyWGCNA/wgcna.py
@@ -377,6 +377,29 @@ class WGCNA(GeneExp):
                                             cutHeight=self.MEDissThres, **kwargs)
             # The merged module colors; Rename to moduleColors
             self.datExpr.var['moduleColors'] = merge['colors']
+
+            # Reassign any singleton modules (1 gene) into the closest module by ME correlation
+            mergedColors = self.datExpr.var['moduleColors']
+            newMEs = merge['newMEs']
+            nonGreyMEs = [c for c in newMEs.columns if c != 'ME' + self.naColor]
+            colorCounts = mergedColors.value_counts()
+            singletons = [c for c in colorCounts[colorCounts == 1].index if c != self.naColor]
+            if singletons and len(nonGreyMEs) > 1:
+                print(f"  Found {len(singletons)} singleton module(s); merging into closest module...", flush=True)
+                expr = self.datExpr.to_df()
+                for sc in singletons:
+                    meCol = 'ME' + sc
+                    if meCol not in newMEs.columns:
+                        continue
+                    gene = mergedColors[mergedColors == sc].index[0]
+                    geneExpr = expr[gene]
+                    otherMEs = newMEs[[c for c in nonGreyMEs if c != meCol]]
+                    if otherMEs.shape[1] == 0:
+                        continue
+                    corr = otherMEs.apply(lambda col: geneExpr.corr(col))
+                    bestColor = corr.idxmax()[2:]  # strip 'ME' prefix
+                    self.datExpr.var.loc[gene, 'moduleColors'] = bestColor
+                    print(f"    module '{sc}' (1 gene: '{gene}') merged into '{bestColor}'", flush=True)
         else:
             self.datExpr.var['moduleColors'] = ["black"] * self.datExpr.shape[1]
 


### PR DESCRIPTION
Fix an issue where cluster merging can leave a singleton module with only one gene.

Since eigengene analysis cannot be performed on a single-gene module and such a module is not meaningful, this patch force-merge it into a neighboring cluster.

There may be more sophisticated approaches in the step of clutser merge, but I think this solution is simple and straightforward.


Error logs are like below.
  File ".../pyWGCNA/_pyWGCNA.py", line 208, in run_wgcna_adata
    return run_wgcna(bulk=bulk, labels=labels, times=times, batch=name,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".../pyWGCNA/_pyWGCNA.py", line 121, in run_wgcna
    wgcna.analyseWGCNA()
  File ".../PyWGCNA/wgcna.py", line 486, in analyseWGCNA
    self.plotModuleEigenGene(module, metadata, show=show)
  File ".../PyWGCNA/wgcna.py", line 2995, in plotModuleEigenGene
    Z = WGCNA.hclust(a, method="average")
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".../PyWGCNA/wgcna.py", line 790, in hclust
    dendrogram = linkage(d, method=method)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".../scipy/cluster/hierarchy.py", line 1049, in linkage
    n = distance.num_obs_y(y)
        ^^^^^^^^^^^^^^^^^^^^^
  File ".../scipy/spatial/distance.py", line 2562, in num_obs_y
    raise ValueError("The number of observations cannot be determined on "
ValueError: The number of observations cannot be determined on an empty distance matrix.
